### PR TITLE
Add explicit bundle parameter to support frameworks

### DIFF
--- a/Tests/Expected/Fonts/default-context-customname.swift
+++ b/Tests/Expected/Fonts/default-context-customname.swift
@@ -27,7 +27,7 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
   }
 }
 
@@ -35,9 +35,15 @@ extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+      #if os(iOS) || os(tvOS) || os(watchOS)
+      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/Tests/Expected/Fonts/default-context-customname.swift
+++ b/Tests/Expected/Fonts/default-context-customname.swift
@@ -19,12 +19,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = NSBundle(forClass: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -62,3 +76,5 @@ enum CustomFamily {
     case Internal = "private"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -27,7 +27,7 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
   }
 }
 
@@ -35,9 +35,15 @@ extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+      #if os(iOS) || os(tvOS) || os(watchOS)
+      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -19,12 +19,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = NSBundle(forClass: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -62,3 +76,5 @@ enum FontFamily {
     case Internal = "private"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-customname.swift
@@ -19,12 +19,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = Bundle(for: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -62,3 +76,5 @@ enum CustomFamily {
     case `internal` = "private"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-customname.swift
@@ -35,9 +35,15 @@ extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      #if os(iOS) || os(tvOS) || os(watchOS)
       if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -19,12 +19,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = Bundle(for: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -62,3 +76,5 @@ enum FontFamily {
     case `internal` = "private"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -35,9 +35,15 @@ extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      #if os(iOS) || os(tvOS) || os(watchOS)
       if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/Tests/Expected/Images/allvalues-context-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-customname.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum XCTImages: String {
+enum XCTImages: String, ImageConvertible {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -32,15 +47,7 @@ enum XCTImages: String {
     Round_Double_Cherry,
     Round_Tomato
   ]
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: XCTImages) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/allvalues-context-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-customname.swift
@@ -11,25 +11,8 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
-
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
-  var image: Image {
-    let bundle = NSBundle(forClass: BundleToken.self)
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
-    #elseif os(OSX)
-    let image = bundle.imageForResource(rawValue)
-    #endif
-    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
-    return result
-  }
-}
-
 // swiftlint:disable type_body_length
-enum XCTImages: String, ImageConvertible {
+enum XCTImages: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -49,6 +32,17 @@ enum XCTImages: String, ImageConvertible {
     Round_Double_Cherry,
     Round_Tomato
   ]
+
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
+    #elseif os(OSX)
+    let image = bundle.imageForResource(rawValue)
+    #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
+  }
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/allvalues-context-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-customname.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -54,9 +56,9 @@ extension Image {
   convenience init!(asset: XCTImages) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/Tests/Expected/Images/allvalues-context-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-customname.swift
@@ -50,4 +50,15 @@ enum XCTImages: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: XCTImages) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -54,9 +56,9 @@ extension Image {
   convenience init!(asset: Asset) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -50,4 +50,15 @@ enum Asset: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: Asset) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -11,25 +11,8 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
-
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
-  var image: Image {
-    let bundle = NSBundle(forClass: BundleToken.self)
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
-    #elseif os(OSX)
-    let image = bundle.imageForResource(rawValue)
-    #endif
-    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
-    return result
-  }
-}
-
 // swiftlint:disable type_body_length
-enum Asset: String, ImageConvertible {
+enum Asset: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -49,6 +32,17 @@ enum Asset: String, ImageConvertible {
     Round_Double_Cherry,
     Round_Tomato
   ]
+
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
+    #elseif os(OSX)
+    let image = bundle.imageForResource(rawValue)
+    #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
+  }
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum Asset: String {
+enum Asset: String, ImageConvertible {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -32,15 +47,7 @@ enum Asset: String {
     Round_Double_Cherry,
     Round_Tomato
   ]
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: Asset) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/default-context-customname.swift
+++ b/Tests/Expected/Images/default-context-customname.swift
@@ -39,4 +39,15 @@ enum XCTImages: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: XCTImages) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/default-context-customname.swift
+++ b/Tests/Expected/Images/default-context-customname.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -43,9 +45,9 @@ extension Image {
   convenience init!(asset: XCTImages) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/Tests/Expected/Images/default-context-customname.swift
+++ b/Tests/Expected/Images/default-context-customname.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum XCTImages: String {
+enum XCTImages: String, ImageConvertible {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -21,15 +36,7 @@ enum XCTImages: String {
   case Round_Apple = "Round/Apple"
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: XCTImages) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/default-context-customname.swift
+++ b/Tests/Expected/Images/default-context-customname.swift
@@ -11,11 +11,17 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
+// swiftlint:disable type_body_length
+enum XCTImages: String {
+  case Exotic_Banana = "Exotic/Banana"
+  case Exotic_Mango = "Exotic/Mango"
+  case Private = "private"
+  case Round_Apricot = "Round/Apricot"
+  case Round_Orange = "Round/Orange"
+  case Round_Apple = "Round/Apple"
+  case Round_Double_Cherry = "Round/Double/Cherry"
+  case Round_Tomato = "Round/Tomato"
 
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
@@ -26,18 +32,6 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
     guard let result = image else { fatalError("Unable to load image \(rawValue).") }
     return result
   }
-}
-
-// swiftlint:disable type_body_length
-enum XCTImages: String, ImageConvertible {
-  case Exotic_Banana = "Exotic/Banana"
-  case Exotic_Mango = "Exotic/Mango"
-  case Private = "private"
-  case Round_Apricot = "Round/Apricot"
-  case Round_Orange = "Round/Orange"
-  case Round_Apple = "Round/Apple"
-  case Round_Double_Cherry = "Round/Double/Cherry"
-  case Round_Tomato = "Round/Tomato"
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -11,11 +11,17 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
+// swiftlint:disable type_body_length
+enum Asset: String {
+  case Exotic_Banana = "Exotic/Banana"
+  case Exotic_Mango = "Exotic/Mango"
+  case Private = "private"
+  case Round_Apricot = "Round/Apricot"
+  case Round_Orange = "Round/Orange"
+  case Round_Apple = "Round/Apple"
+  case Round_Double_Cherry = "Round/Double/Cherry"
+  case Round_Tomato = "Round/Tomato"
 
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
@@ -26,18 +32,6 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
     guard let result = image else { fatalError("Unable to load image \(rawValue).") }
     return result
   }
-}
-
-// swiftlint:disable type_body_length
-enum Asset: String, ImageConvertible {
-  case Exotic_Banana = "Exotic/Banana"
-  case Exotic_Mango = "Exotic/Mango"
-  case Private = "private"
-  case Round_Apricot = "Round/Apricot"
-  case Round_Orange = "Round/Orange"
-  case Round_Apple = "Round/Apple"
-  case Round_Double_Cherry = "Round/Double/Cherry"
-  case Round_Tomato = "Round/Tomato"
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -39,4 +39,15 @@ enum Asset: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: Asset) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum Asset: String {
+enum Asset: String, ImageConvertible {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
   case Private = "private"
@@ -21,15 +36,7 @@ enum Asset: String {
   case Round_Apple = "Round/Apple"
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: Asset) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -43,9 +45,9 @@ extension Image {
   convenience init!(asset: Asset) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/Tests/Expected/Images/dot-syntax-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-context-customname.swift
@@ -18,9 +18,9 @@ struct XCTImagesType: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    return bundle.imageForResource(value)!
     #endif
   }
 
@@ -57,5 +57,16 @@ enum XCTImages {
   }
 }
 // swiftlint:enable type_body_length
+
+extension Image {
+  convenience init!(asset: XCTImagesType) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)!
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-context-customname.swift
@@ -18,10 +18,12 @@ struct XCTImagesType: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(value)!
+    let image = bundle.imageForResource(value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -62,9 +64,9 @@ extension Image {
   convenience init!(asset: XCTImagesType) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.value)!
+    self.init(named: asset.value)
     #endif
   }
 }

--- a/Tests/Expected/Images/dot-syntax-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-context-customname.swift
@@ -15,8 +15,13 @@
 struct XCTImagesType: StringLiteralConvertible {
   private var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -53,8 +58,4 @@ enum XCTImages {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: XCTImagesType) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults.swift
@@ -18,10 +18,12 @@ struct AssetType: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(value)!
+    let image = bundle.imageForResource(value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -62,9 +64,9 @@ extension Image {
   convenience init!(asset: AssetType) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.value)!
+    self.init(named: asset.value)
     #endif
   }
 }

--- a/Tests/Expected/Images/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults.swift
@@ -15,8 +15,13 @@
 struct AssetType: StringLiteralConvertible {
   private var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -53,8 +58,4 @@ enum Asset {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: AssetType) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults.swift
@@ -18,9 +18,9 @@ struct AssetType: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    return bundle.imageForResource(value)!
     #endif
   }
 
@@ -57,5 +57,16 @@ enum Asset {
   }
 }
 // swiftlint:enable type_body_length
+
+extension Image {
+  convenience init!(asset: AssetType) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)!
+    #endif
+  }
+}
 
 private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
@@ -18,10 +18,12 @@ struct XCTImagesType: ExpressibleByStringLiteral {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, in: bundle, compatibleWith: nil)!
+    let image = Image(named: value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: value)!
+    let image = bundle.image(forResource: value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -62,7 +64,7 @@ extension Image {
   convenience init!(asset: XCTImagesType) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.value)
     #endif

--- a/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
@@ -15,8 +15,13 @@
 struct XCTImagesType: ExpressibleByStringLiteral {
   fileprivate var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: value)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -53,8 +58,4 @@ enum XCTImages {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: XCTImagesType) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-customname.swift
@@ -58,4 +58,15 @@ enum XCTImages {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: XCTImagesType) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
@@ -58,4 +58,15 @@ enum Asset {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: AssetType) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
@@ -15,8 +15,13 @@
 struct AssetType: ExpressibleByStringLiteral {
   fileprivate var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: value)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -53,8 +58,4 @@ enum Asset {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: AssetType) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
@@ -18,10 +18,12 @@ struct AssetType: ExpressibleByStringLiteral {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, in: bundle, compatibleWith: nil)!
+    let image = Image(named: value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: value)!
+    let image = bundle.image(forResource: value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -62,7 +64,7 @@ extension Image {
   convenience init!(asset: AssetType) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.value)
     #endif

--- a/Tests/Expected/Images/swift3-context-customname.swift
+++ b/Tests/Expected/Images/swift3-context-customname.swift
@@ -39,4 +39,15 @@ enum XCTImages: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: XCTImages) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/swift3-context-customname.swift
+++ b/Tests/Expected/Images/swift3-context-customname.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    let image = Image(named: rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: rawValue)!
+    let image = bundle.image(forResource: rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -43,7 +45,7 @@ extension Image {
   convenience init!(asset: XCTImages) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.rawValue)
     #endif

--- a/Tests/Expected/Images/swift3-context-customname.swift
+++ b/Tests/Expected/Images/swift3-context-customname.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum XCTImages: String {
+enum XCTImages: String, ImageConvertible {
   case exoticBanana = "Exotic/Banana"
   case exoticMango = "Exotic/Mango"
   case `private` = "private"
@@ -21,15 +36,7 @@ enum XCTImages: String {
   case roundApple = "Round/Apple"
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: XCTImages) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Images/swift3-context-customname.swift
+++ b/Tests/Expected/Images/swift3-context-customname.swift
@@ -11,11 +11,17 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
+// swiftlint:disable type_body_length
+enum XCTImages: String {
+  case exoticBanana = "Exotic/Banana"
+  case exoticMango = "Exotic/Mango"
+  case `private` = "private"
+  case roundApricot = "Round/Apricot"
+  case roundOrange = "Round/Orange"
+  case roundApple = "Round/Apple"
+  case roundDoubleCherry = "Round/Double/Cherry"
+  case roundTomato = "Round/Tomato"
 
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
@@ -26,18 +32,6 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
     guard let result = image else { fatalError("Unable to load image \(rawValue).") }
     return result
   }
-}
-
-// swiftlint:disable type_body_length
-enum XCTImages: String, ImageConvertible {
-  case exoticBanana = "Exotic/Banana"
-  case exoticMango = "Exotic/Mango"
-  case `private` = "private"
-  case roundApricot = "Round/Apricot"
-  case roundOrange = "Round/Orange"
-  case roundApple = "Round/Apple"
-  case roundDoubleCherry = "Round/Double/Cherry"
-  case roundTomato = "Round/Tomato"
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -19,10 +19,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    let image = Image(named: rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: rawValue)!
+    let image = bundle.image(forResource: rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 
@@ -43,7 +45,7 @@ extension Image {
   convenience init!(asset: Asset) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.rawValue)
     #endif

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -11,11 +11,17 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
-protocol ImageConvertible {
-  var image: Image { get }
-}
+// swiftlint:disable type_body_length
+enum Asset: String {
+  case exoticBanana = "Exotic/Banana"
+  case exoticMango = "Exotic/Mango"
+  case `private` = "private"
+  case roundApricot = "Round/Apricot"
+  case roundOrange = "Round/Orange"
+  case roundApple = "Round/Apple"
+  case roundDoubleCherry = "Round/Double/Cherry"
+  case roundTomato = "Round/Tomato"
 
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
@@ -26,18 +32,6 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
     guard let result = image else { fatalError("Unable to load image \(rawValue).") }
     return result
   }
-}
-
-// swiftlint:disable type_body_length
-enum Asset: String, ImageConvertible {
-  case exoticBanana = "Exotic/Banana"
-  case exoticMango = "Exotic/Mango"
-  case `private` = "private"
-  case roundApricot = "Round/Apricot"
-  case roundOrange = "Round/Orange"
-  case roundApple = "Round/Apple"
-  case roundDoubleCherry = "Round/Double/Cherry"
-  case roundTomato = "Round/Tomato"
 }
 // swiftlint:enable type_body_length
 

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -39,4 +39,15 @@ enum Asset: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: Asset) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)
+    #endif
+  }
+}
+
 private final class BundleToken {}

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -11,8 +11,23 @@
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: rawValue)!
+    #endif
+  }
+}
+
 // swiftlint:disable type_body_length
-enum Asset: String {
+enum Asset: String, ImageConvertible {
   case exoticBanana = "Exotic/Banana"
   case exoticMango = "Exotic/Mango"
   case `private` = "private"
@@ -21,15 +36,7 @@ enum Asset: String {
   case roundApple = "Round/Apple"
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: Asset) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-customname.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {

--- a/Tests/Expected/Storyboards-iOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-empty.swift
@@ -3,42 +3,4 @@
 import Foundation
 import UIKit
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
-  }
-
-  static func initialViewController() -> UIViewController {
-    guard let vc = storyboard().instantiateInitialViewController() else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return vc
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> UIViewController {
-    return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
-  }
-  static func viewController(identifier: Self) -> UIViewController {
-    return identifier.viewController()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-customname.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
@@ -3,42 +3,4 @@
 import Foundation
 import UIKit
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
-  }
-
-  static func initialViewController() -> UIViewController {
-    guard let vc = storyboard().instantiateInitialViewController() else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return vc
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> UIViewController {
-    return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
-  }
-  static func viewController(identifier: Self) -> UIViewController {
-    return identifier.viewController()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum StoryboardSegue {
     case showPassword = "ShowPassword"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-customname.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum XCTStoryboardsSegue {
     case showPassword = "ShowPassword"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {

--- a/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
@@ -3,42 +3,4 @@
 import Foundation
 import UIKit
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-
-  static func initialViewController() -> UIViewController {
-    guard let vc = storyboard().instantiateInitialViewController() else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return vc
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> UIViewController {
-    return Self.storyboard().instantiateViewController(withIdentifier: self.rawValue)
-  }
-  static func viewController(identifier: Self) -> UIViewController {
-    return identifier.viewController()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension UIViewController {
-  func perform<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-customname.swift
@@ -16,7 +16,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -183,3 +183,5 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
@@ -3,42 +3,4 @@
 import Foundation
 import UIKit
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
-  }
-
-  static func initialViewController() -> UIViewController {
-    guard let vc = storyboard().instantiateInitialViewController() else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return vc
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func viewController() -> UIViewController {
-    return Self.storyboard().instantiateViewControllerWithIdentifier(self.rawValue)
-  }
-  static func viewController(identifier: Self) -> UIViewController {
-    return identifier.viewController()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension UIViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -167,3 +167,5 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-customname.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -167,3 +167,5 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {

--- a/Tests/Expected/Storyboards-macOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-empty.swift
@@ -3,49 +3,4 @@
 import Foundation
 import Cocoa
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
-  }
-
-  static func initialController() -> AnyObject {
-    guard let controller = storyboard().instantiateInitialController()
-    else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return controller
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func controller() -> AnyObject {
-    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
-  }
-  static func controller(identifier: Self) -> AnyObject {
-    return identifier.controller()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension NSWindowController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
-extension NSViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -167,3 +167,5 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-customname.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -167,3 +167,5 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
@@ -3,49 +3,4 @@
 import Foundation
 import Cocoa
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
-  }
-
-  static func initialController() -> AnyObject {
-    guard let controller = storyboard().instantiateInitialController()
-    else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return controller
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func controller() -> AnyObject {
-    return Self.storyboard().instantiateControllerWithIdentifier(self.rawValue)
-  }
-  static func controller(identifier: Self) -> AnyObject {
-    return identifier.controller()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension NSWindowController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
-extension NSViewController {
-  func performSegue<S: StoryboardSegueType where S.RawValue == String>(segue: S, sender: AnyObject? = nil) {
-    performSegueWithIdentifier(segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialController() -> Any {
@@ -167,3 +167,5 @@ enum StoryboardSegue {
     case `public`
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-customname.swift
@@ -14,7 +14,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialController() -> Any {
@@ -167,3 +167,5 @@ enum XCTStoryboardsSegue {
     case `public`
   }
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
@@ -13,7 +13,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialController() -> Any {

--- a/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
@@ -3,49 +3,4 @@
 import Foundation
 import Cocoa
 
-// swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-
-protocol StoryboardSceneType {
-  static var storyboardName: String { get }
-}
-
-extension StoryboardSceneType {
-  static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
-  }
-
-  static func initialController() -> Any {
-    guard let controller = storyboard().instantiateInitialController()
-    else {
-      fatalError("Failed to instantiate initialViewController for \(self.storyboardName)")
-    }
-    return controller
-  }
-}
-
-extension StoryboardSceneType where Self: RawRepresentable, Self.RawValue == String {
-  func controller() -> Any {
-    return Self.storyboard().instantiateController(withIdentifier: self.rawValue)
-  }
-  static func controller(identifier: Self) -> Any {
-    return identifier.controller()
-  }
-}
-
-protocol StoryboardSegueType: RawRepresentable { }
-
-extension NSWindowController {
-  func performSegue<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
-
-extension NSViewController {
-  func performSegue<S: StoryboardSegueType>(segue: S, sender: Any? = nil) where S.RawValue == String {
-    performSegue(withIdentifier: segue.rawValue, sender: sender)
-  }
-}
-
 // No storyboard found

--- a/Tests/Expected/Strings/default-context-customname.swift
+++ b/Tests/Expected/Strings/default-context-customname.swift
@@ -63,7 +63,7 @@ extension XCTLoc: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/default-context-defaults.swift
+++ b/Tests/Expected/Strings/default-context-defaults.swift
@@ -63,7 +63,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/dot-syntax-context-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-customname.swift
@@ -94,10 +94,12 @@ enum XCTLoc {
 
 extension XCTLoc {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/Tests/Expected/Strings/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-defaults.swift
@@ -94,10 +94,12 @@ enum L10n {
 
 extension L10n {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-customname.swift
@@ -94,10 +94,12 @@ enum XCTLoc {
 
 extension XCTLoc {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
@@ -94,10 +94,12 @@ enum L10n {
 
 extension L10n {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/Tests/Expected/Strings/genstrings-context-customname.swift
+++ b/Tests/Expected/Strings/genstrings-context-customname.swift
@@ -35,37 +35,37 @@ extension XCTLoc: CustomStringConvertible {
   var string: String {
     switch self {
       case .AlertMessage:
-        let format = NSLocalizedString("alert_message", comment: "")
+        let format = NSLocalizedString("alert_message", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .AlertTitle:
-        let format = NSLocalizedString("alert_title", comment: "")
+        let format = NSLocalizedString("alert_title", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .ObjectOwnership(let p1, let p2, let p3):
-        let format = NSLocalizedString("ObjectOwnership", comment: "")
+        let format = NSLocalizedString("ObjectOwnership", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format, p1, p2, p3)
       case .Private(let p1, let p2):
-        let format = NSLocalizedString("private", comment: "")
+        let format = NSLocalizedString("private", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format, p1, p2)
       case .ApplesCount(let p1):
-        let format = NSLocalizedString("apples.count", comment: "")
+        let format = NSLocalizedString("apples.count", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format, p1)
       case .BananasOwner(let p1, let p2):
-        let format = NSLocalizedString("bananas.owner", comment: "")
+        let format = NSLocalizedString("bananas.owner", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format, p1, p2)
       case .SettingsNavigationBarSelf:
-        let format = NSLocalizedString("settings.navigation-bar.self", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.self", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .SettingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep:
-        let format = NSLocalizedString("settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .SettingsNavigationBarTitleEvenDeeper:
-        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .SeTTingsUSerProFileSectioNFooterText:
-        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", comment: "")
+        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
       case .SettingsUserProfileSectionHeaderTitle:
-        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", comment: "")
+        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return XCTLoc.tr(format)
     }
   }
@@ -78,3 +78,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/genstrings-context-defaults.swift
+++ b/Tests/Expected/Strings/genstrings-context-defaults.swift
@@ -35,37 +35,37 @@ extension L10n: CustomStringConvertible {
   var string: String {
     switch self {
       case .AlertMessage:
-        let format = NSLocalizedString("alert_message", comment: "")
+        let format = NSLocalizedString("alert_message", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .AlertTitle:
-        let format = NSLocalizedString("alert_title", comment: "")
+        let format = NSLocalizedString("alert_title", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .ObjectOwnership(let p1, let p2, let p3):
-        let format = NSLocalizedString("ObjectOwnership", comment: "")
+        let format = NSLocalizedString("ObjectOwnership", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format, p1, p2, p3)
       case .Private(let p1, let p2):
-        let format = NSLocalizedString("private", comment: "")
+        let format = NSLocalizedString("private", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format, p1, p2)
       case .ApplesCount(let p1):
-        let format = NSLocalizedString("apples.count", comment: "")
+        let format = NSLocalizedString("apples.count", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format, p1)
       case .BananasOwner(let p1, let p2):
-        let format = NSLocalizedString("bananas.owner", comment: "")
+        let format = NSLocalizedString("bananas.owner", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format, p1, p2)
       case .SettingsNavigationBarSelf:
-        let format = NSLocalizedString("settings.navigation-bar.self", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.self", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .SettingsNavigationBarTitleDeeperThanWeCanHandleNoReallyThisIsDeep:
-        let format = NSLocalizedString("settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.deeper.than.we.can.handle.no.really.this.is.deep", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .SettingsNavigationBarTitleEvenDeeper:
-        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", comment: "")
+        let format = NSLocalizedString("settings.navigation-bar.title.even.deeper", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .SeTTingsUSerProFileSectioNFooterText:
-        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", comment: "")
+        let format = NSLocalizedString("seTTings.uSer-proFile-sectioN.footer_text", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
       case .SettingsUserProfileSectionHeaderTitle:
-        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", comment: "")
+        let format = NSLocalizedString("SETTINGS.USER_PROFILE_SECTION.HEADER_TITLE", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return L10n.tr(format)
     }
   }
@@ -78,3 +78,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/no-comments-swift3-context-customname.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-customname.swift
@@ -52,7 +52,7 @@ extension XCTLoc: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -60,3 +60,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(_ key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
@@ -52,7 +52,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -60,3 +60,5 @@ extension L10n: CustomStringConvertible {
 func tr(_ key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/structured-context-customname.swift
+++ b/Tests/Expected/Strings/structured-context-customname.swift
@@ -192,7 +192,7 @@ extension XCTLoc: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -203,3 +203,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/structured-context-defaults.swift
+++ b/Tests/Expected/Strings/structured-context-defaults.swift
@@ -192,7 +192,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -203,3 +203,5 @@ extension L10n: CustomStringConvertible {
 func tr(key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/swift3-context-customname.swift
+++ b/Tests/Expected/Strings/swift3-context-customname.swift
@@ -63,7 +63,7 @@ extension XCTLoc: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension XCTLoc: CustomStringConvertible {
 func tr(_ key: XCTLoc) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/Tests/Expected/Strings/swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/swift3-context-defaults.swift
@@ -63,7 +63,7 @@ extension L10n: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -71,3 +71,5 @@ extension L10n: CustomStringConvertible {
 func tr(_ key: L10n) -> String {
   return key.string
 }
+
+private final class BundleToken {}

--- a/templates/fonts-default.stencil
+++ b/templates/fonts-default.stencil
@@ -20,12 +20,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = NSBundle(forClass: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -39,6 +53,8 @@ enum {{enumName}} {
   }
   {% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No fonts found
 {% endif %}

--- a/templates/fonts-default.stencil
+++ b/templates/fonts-default.stencil
@@ -28,7 +28,7 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
   }
 }
 
@@ -36,9 +36,15 @@ extension Font {
   convenience init!<FontType: FontConvertible
     where FontType: RawRepresentable, FontType.RawValue == String>
     (font: FontType, size: CGFloat) {
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+      #if os(iOS) || os(tvOS) || os(watchOS)
+      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/templates/fonts-swift3.stencil
+++ b/templates/fonts-swift3.stencil
@@ -36,9 +36,15 @@ extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      #if os(iOS) || os(tvOS) || os(watchOS)
       if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
         font.register()
       }
+      #elseif os(OSX)
+      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
+        font.register()
+      }
+      #endif
 
       self.init(name: font.rawValue, size: size)
   }

--- a/templates/fonts-swift3.stencil
+++ b/templates/fonts-swift3.stencil
@@ -20,12 +20,26 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
+
+  func register() {
+    let extensions = ["otf", "ttf"]
+    let bundle = Bundle(for: BundleToken.self)
+
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+
+    var errorRef: Unmanaged<CFError>?
+    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+  }
 }
 
 extension Font {
   convenience init!<FontType: FontConvertible>
     (font: FontType, size: CGFloat)
     where FontType: RawRepresentable, FontType.RawValue == String {
+      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
+        font.register()
+      }
+
       self.init(name: font.rawValue, size: size)
   }
 }
@@ -39,6 +53,8 @@ enum {{enumName}} {
   }
   {% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No fonts found
 {% endif %}

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -20,10 +20,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 {% macro recursiveCaseBlock images %}
@@ -63,9 +65,9 @@ extension Image {
   convenience init!(asset: {{enumName}}) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -59,6 +59,17 @@ enum {{enumName}}: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: {{enumName}}) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}
 {% else %}
 // No image found

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -11,6 +11,21 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
 {% macro recursiveCaseBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -31,7 +46,7 @@
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String {
+enum {{enumName}}: String, ImageConvertible {
   {% for catalog in catalogs %}
   {% call recursiveCaseBlock catalog.assets %}
   {% endfor %}
@@ -41,18 +56,10 @@ enum {{enumName}}: String {
     {% call recursiveValueBlock catalog.assets false %}
     {% endfor %}
   ]
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: {{enumName}}) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}
 {% else %}
 // No image found
 {% endif %}

--- a/templates/images-allvalues.stencil
+++ b/templates/images-allvalues.stencil
@@ -11,23 +11,6 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
-
-protocol ImageConvertible {
-  var image: Image { get }
-}
-
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
-  var image: Image {
-    let bundle = NSBundle(forClass: BundleToken.self)
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
-    #elseif os(OSX)
-    let image = bundle.imageForResource(rawValue)
-    #endif
-    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
-    return result
-  }
-}
 {% macro recursiveCaseBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -48,7 +31,7 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String, ImageConvertible {
+enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveCaseBlock catalog.assets %}
   {% endfor %}
@@ -58,6 +41,17 @@ enum {{enumName}}: String, ImageConvertible {
     {% call recursiveValueBlock catalog.assets false %}
     {% endfor %}
   ]
+
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
+    #elseif os(OSX)
+    let image = bundle.imageForResource(rawValue)
+    #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
+  }
 }
 // swiftlint:enable type_body_length
 

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -11,6 +11,21 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
+  }
+}
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -22,22 +37,14 @@
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String {
+enum {{enumName}}: String, ImageConvertible {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: {{enumName}}) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}
 {% else %}
 // No image found
 {% endif %}

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -44,6 +44,17 @@ enum {{enumName}}: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: {{enumName}}) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)!
+    #endif
+  }
+}
+
 private final class BundleToken {}
 {% else %}
 // No image found

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -20,10 +20,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    let image = bundle.imageForResource(rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 {% macro recursiveBlock images %}
@@ -48,9 +50,9 @@ extension Image {
   convenience init!(asset: {{enumName}}) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.rawValue)!
+    self.init(named: asset.rawValue)
     #endif
   }
 }

--- a/templates/images-default.stencil
+++ b/templates/images-default.stencil
@@ -11,23 +11,6 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
-
-protocol ImageConvertible {
-  var image: Image { get }
-}
-
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
-  var image: Image {
-    let bundle = NSBundle(forClass: BundleToken.self)
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
-    #elseif os(OSX)
-    let image = bundle.imageForResource(rawValue)
-    #endif
-    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
-    return result
-  }
-}
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -39,10 +22,21 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String, ImageConvertible {
+enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
+
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let image = Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)
+    #elseif os(OSX)
+    let image = bundle.imageForResource(rawValue)
+    #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
+  }
 }
 // swiftlint:enable type_body_length
 

--- a/templates/images-dot-syntax-swift3.stencil
+++ b/templates/images-dot-syntax-swift3.stencil
@@ -64,6 +64,17 @@ enum {{enumName}} {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: {{enumName}}Type) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)
+    #endif
+  }
+}
+
 private final class BundleToken {}
 {% else %}
 // No image found

--- a/templates/images-dot-syntax-swift3.stencil
+++ b/templates/images-dot-syntax-swift3.stencil
@@ -19,10 +19,12 @@ struct {{enumName}}Type: ExpressibleByStringLiteral {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, in: bundle, compatibleWith: nil)!
+    let image = Image(named: value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: value)!
+    let image = bundle.image(forResource: value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -68,7 +70,7 @@ extension Image {
   convenience init!(asset: {{enumName}}Type) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.value, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.value, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.value)
     #endif

--- a/templates/images-dot-syntax-swift3.stencil
+++ b/templates/images-dot-syntax-swift3.stencil
@@ -16,8 +16,13 @@
 struct {{enumName}}Type: ExpressibleByStringLiteral {
   fileprivate var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: value, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: value)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -59,11 +64,7 @@ enum {{enumName}} {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: {{enumName}}Type) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}
 {% else %}
 // No image found
 {% endif %}

--- a/templates/images-dot-syntax.stencil
+++ b/templates/images-dot-syntax.stencil
@@ -19,10 +19,12 @@ struct {{enumName}}Type: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    let image = Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    return bundle.imageForResource(value)!
+    let image = bundle.imageForResource(value)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(value).") }
+    return result
   }
 
   init(stringLiteral value: String) {
@@ -68,9 +70,9 @@ extension Image {
   convenience init!(asset: {{enumName}}Type) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = NSBundle(forClass: BundleToken.self)
-    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)
     #elseif os(OSX)
-    self.init(named: asset.value)!
+    self.init(named: asset.value)
     #endif
   }
 }

--- a/templates/images-dot-syntax.stencil
+++ b/templates/images-dot-syntax.stencil
@@ -19,9 +19,9 @@ struct {{enumName}}Type: StringLiteralConvertible {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    return Image(named: value, inBundle: bundle, compatibleWithTraitCollection: nil)!
     #elseif os(OSX)
-    return bundle.imageForResource(rawValue)!
+    return bundle.imageForResource(value)!
     #endif
   }
 
@@ -63,6 +63,17 @@ enum {{enumName}} {
   {% endif %}
 }
 // swiftlint:enable type_body_length
+
+extension Image {
+  convenience init!(asset: {{enumName}}Type) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = NSBundle(forClass: BundleToken.self)
+    self.init(named: asset.value, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.value)!
+    #endif
+  }
+}
 
 private final class BundleToken {}
 {% else %}

--- a/templates/images-dot-syntax.stencil
+++ b/templates/images-dot-syntax.stencil
@@ -16,8 +16,13 @@
 struct {{enumName}}Type: StringLiteralConvertible {
   private var value: String
 
-  var image: UIImage {
-    return UIImage(asset: self)
+  var image: Image {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, inBundle: bundle, compatibleWithTraitCollection: nil)!
+    #elseif os(OSX)
+    return bundle.imageForResource(rawValue)!
+    #endif
   }
 
   init(stringLiteral value: String) {
@@ -59,11 +64,7 @@ enum {{enumName}} {
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: {{enumName}}Type) {
-    self.init(named: asset.value)
-  }
-}
+private final class BundleToken {}
 {% else %}
 // No image found
 {% endif %}

--- a/templates/images-swift3.stencil
+++ b/templates/images-swift3.stencil
@@ -11,23 +11,6 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
-
-protocol ImageConvertible {
-  var image: Image { get }
-}
-
-extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
-  var image: Image {
-    let bundle = Bundle(for: BundleToken.self)
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    let image = Image(named: rawValue, in: bundle, compatibleWith: nil)
-    #elseif os(OSX)
-    let image = bundle.image(forResource: rawValue)
-    #endif
-    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
-    return result
-  }
-}
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -39,10 +22,21 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String, ImageConvertible {
+enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
+
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let image = Image(named: rawValue, in: bundle, compatibleWith: nil)
+    #elseif os(OSX)
+    let image = bundle.image(forResource: rawValue)
+    #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
+  }
 }
 // swiftlint:enable type_body_length
 

--- a/templates/images-swift3.stencil
+++ b/templates/images-swift3.stencil
@@ -20,10 +20,12 @@ extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS) || os(watchOS)
-    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    let image = Image(named: rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
-    return bundle.image(forResource: rawValue)!
+    let image = bundle.image(forResource: rawValue)
     #endif
+    guard let result = image else { fatalError("Unable to load image \(rawValue).") }
+    return result
   }
 }
 {% macro recursiveBlock images %}
@@ -48,7 +50,7 @@ extension Image {
   convenience init!(asset: {{enumName}}) {
     #if os(iOS) || os(tvOS) || os(watchOS)
     let bundle = Bundle(for: BundleToken.self)
-    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)
     #elseif os(OSX)
     self.init(named: asset.rawValue)
     #endif

--- a/templates/images-swift3.stencil
+++ b/templates/images-swift3.stencil
@@ -11,6 +11,21 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+
+protocol ImageConvertible {
+  var image: Image { get }
+}
+
+extension ImageConvertible where Self: RawRepresentable, Self.RawValue == String {
+  var image: Image {
+    let bundle = Bundle(for: BundleToken.self)
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    return Image(named: rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    return bundle.image(forResource: rawValue)!
+    #endif
+  }
+}
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -22,22 +37,14 @@
 {% endmacro %}
 
 // swiftlint:disable type_body_length
-enum {{enumName}}: String {
+enum {{enumName}}: String, ImageConvertible {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
-
-  var image: Image {
-    return Image(asset: self)
-  }
 }
 // swiftlint:enable type_body_length
 
-extension Image {
-  convenience init!(asset: {{enumName}}) {
-    self.init(named: asset.rawValue)
-  }
-}
+private final class BundleToken {}
 {% else %}
 // No image found
 {% endif %}

--- a/templates/images-swift3.stencil
+++ b/templates/images-swift3.stencil
@@ -44,6 +44,17 @@ enum {{enumName}}: String, ImageConvertible {
 }
 // swiftlint:enable type_body_length
 
+extension Image {
+  convenience init!(asset: {{enumName}}) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    let bundle = Bundle(for: BundleToken.self)
+    self.init(named: asset.rawValue, in: bundle, compatibleWith: nil)!
+    #elseif os(OSX)
+    self.init(named: asset.rawValue)
+    #endif
+  }
+}
+
 private final class BundleToken {}
 {% else %}
 // No image found

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -7,6 +7,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -47,7 +48,6 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-default.stencil
+++ b/templates/storyboards-default.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -112,6 +112,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -7,6 +7,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -47,7 +48,6 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-lowercase.stencil
+++ b/templates/storyboards-lowercase.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -112,6 +112,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -7,6 +7,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -54,7 +55,6 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-osx-default.stencil
+++ b/templates/storyboards-osx-default.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -93,6 +93,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-osx-lowercase.stencil
+++ b/templates/storyboards-osx-lowercase.stencil
@@ -7,6 +7,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -54,7 +55,6 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-osx-lowercase.stencil
+++ b/templates/storyboards-osx-lowercase.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialController() -> AnyObject {
@@ -93,6 +93,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-osx-swift3.stencil
+++ b/templates/storyboards-osx-swift3.stencil
@@ -7,6 +7,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -54,7 +55,6 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-osx-swift3.stencil
+++ b/templates/storyboards-osx-swift3.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> NSStoryboard {
-    return NSStoryboard(name: self.storyboardName, bundle: nil)
+    return NSStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialController() -> Any {
@@ -93,6 +93,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -7,6 +7,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -47,7 +48,6 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-swift3.stencil
+++ b/templates/storyboards-swift3.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: Bundle(for: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -112,6 +112,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/storyboards-uppercase.stencil
+++ b/templates/storyboards-uppercase.stencil
@@ -7,6 +7,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
+{% if storyboards %}
 // swiftlint:disable file_length
 // swiftlint:disable line_length
 // swiftlint:disable type_body_length
@@ -47,7 +48,6 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-{% if storyboards %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
   {% set storyboardName %}{{storyboard.name|swiftIdentifier|escapeReservedKeywords}}{% endset %}

--- a/templates/storyboards-uppercase.stencil
+++ b/templates/storyboards-uppercase.stencil
@@ -18,7 +18,7 @@ protocol StoryboardSceneType {
 
 extension StoryboardSceneType {
   static func storyboard() -> UIStoryboard {
-    return UIStoryboard(name: self.storyboardName, bundle: nil)
+    return UIStoryboard(name: self.storyboardName, bundle: NSBundle(forClass: BundleToken.self))
   }
 
   static func initialViewController() -> UIViewController {
@@ -112,6 +112,8 @@ enum {{segueEnumName}} {
   }
   {% endif %}{% endfor %}
 }
+
+private final class BundleToken {}
 {% else %}
 // No storyboard found
 {% endif %}

--- a/templates/strings-default.stencil
+++ b/templates/strings-default.stencil
@@ -47,7 +47,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -55,6 +55,8 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-dot-syntax-swift3.stencil
+++ b/templates/strings-dot-syntax-swift3.stencil
@@ -39,10 +39,12 @@ enum {{enumName}} {
 
 extension {{enumName}} {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/templates/strings-dot-syntax.stencil
+++ b/templates/strings-dot-syntax.stencil
@@ -39,10 +39,12 @@ enum {{enumName}} {
 
 extension {{enumName}} {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+
+private final class BundleToken {}
 
 // swiftlint:enable type_body_length
 // swiftlint:enable nesting

--- a/templates/strings-genstrings.stencil
+++ b/templates/strings-genstrings.stencil
@@ -24,11 +24,11 @@ enum {{enumName}} {
       {% for string in strings.strings %}
       {% if string.params %}
       case .{{string.key|swiftIdentifier|snakeToCamelCase|escapeReservedKeywords}}({% call parametersBlock string.params %}):
-        let format = NSLocalizedString("{{string.key}}", comment: "")
+        let format = NSLocalizedString("{{string.key}}", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return {{enumName}}.tr(format, {% call argumentsBlock string.params %})
       {% else %}
       case .{{string.key|swiftIdentifier|snakeToCamelCase|escapeReservedKeywords}}:
-        let format = NSLocalizedString("{{string.key}}", comment: "")
+        let format = NSLocalizedString("{{string.key}}", bundle: NSBundle(forClass: BundleToken.self), comment: "")
         return {{enumName}}.tr(format)
       {% endif %}
       {% endfor %}
@@ -53,6 +53,8 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-no-comments-swift3.stencil
+++ b/templates/strings-no-comments-swift3.stencil
@@ -46,7 +46,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -54,6 +54,8 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(_ key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-structured.stencil
+++ b/templates/strings-structured.stencil
@@ -60,7 +60,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArgType...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: NSBundle(forClass: BundleToken.self), comment: "")
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
@@ -71,6 +71,8 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings-swift3.stencil
+++ b/templates/strings-swift3.stencil
@@ -47,7 +47,7 @@ extension {{enumName}}: CustomStringConvertible {
   }
 
   private static func tr(key: String, _ args: CVarArg...) -> String {
-    let format = NSLocalizedString(key, comment: "")
+    let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
@@ -55,6 +55,8 @@ extension {{enumName}}: CustomStringConvertible {
 func tr(_ key: {{enumName}}) -> String {
   return key.string
 }
+
+private final class BundleToken {}
 {% else %}
 // No string found
 {% endif %}


### PR DESCRIPTION
Carry over changes from https://github.com/AliSoftware/SwiftGen/pull/255 with some added fixes for Swift 2.3. I've also implemented the same changes for storyboards.

This still needs some work to add this to the other commands, for example:
- images: the way to load assets from catalogs in bundles is different between iOS (`UIImage(named:in:compatibleWith:)`) and macOS (`bundle.image(forResource:)`)
- fonts: the fonts need to be registered using `CTFontManagerRegisterFontsForURL` before use. I've done this using an override of `initialize()`  in a Font extension, but we could also just check in our `init` if it's already loaded. Would love some input on the preferred method for this.