### PR TITLE
Added a strings-swift3 template with public enums

### DIFF
--- a/templates/strings-swift3-public.stencil
+++ b/templates/strings-swift3-public.stencil
@@ -1,0 +1,46 @@
+// Generated using SwiftGen, by O.Halligon — https://github.com/AliSoftware/SwiftGen
+
+{% if strings %}
+import Foundation
+
+// swiftlint:disable file_length
+// swiftlint:disable line_length
+
+// swiftlint:disable type_body_length
+public enum {{enumName}} {
+  {% for string in strings %}
+  /// {{string.translation}}
+  case {{string.key|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}{% if string.params %}({{string.params.types|join}}){% endif %}
+  {% endfor %}
+}
+// swiftlint:enable type_body_length
+
+extension {{enumName}}: CustomStringConvertible {
+  public var description: String { return self.string }
+
+  public var string: String {
+    switch self {
+      {% for string in strings %}
+      {% if string.params %}
+      case .{{string.key|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}({{string.params.declarations|join}}):
+        return {{enumName}}.tr(key: "{{string.key}}", {{string.params.names|join}})
+      {% else %}
+      case .{{string.key|swiftIdentifier|snakeToCamelCase|lowerFirstWord}}:
+        return {{enumName}}.tr(key: "{{string.key}}")
+      {% endif %}
+      {% endfor %}
+    }
+  }
+
+  private static func tr(key: String, _ args: CVarArg...) -> String {
+    let format = NSLocalizedString(key, comment: "")
+    return String(format: format, locale: Locale.current, arguments: args)
+  }
+}
+
+func tr(_ key: {{enumName}}) -> String {
+  return key.string
+}
+{% else %}
+// No string found
+{% endif %}


### PR DESCRIPTION
I would like to use the generated enum with my strings in a framework that contains all my constants. Therefore I had to make some properties public. Because I already did this for myself, I thought why not share it.

What I did:

- Copied the strings-swift3 template and marked the required properties and enums as public for use in frameworks.