### PR TITLE
Swiftlint rules in color templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Bug Fixes
 
-* Fixed `swiftlint` warnings in generated color extensions
+* Fixed `swiftlint` warnings in generated color extensions.  
+[Roman Laitarenko](https://github.com/evil159) 
+[#32](https://github.com/SwiftGen/templates/pull/32)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-_None_
+* Fixed `swiftlint` warnings in generated color extensions
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Bug Fixes
 
 * Fixed `swiftlint` warnings in generated color extensions.  
-[Roman Laitarenko](https://github.com/evil159) 
-[#32](https://github.com/SwiftGen/templates/pull/32)
+  [Roman Laitarenko](https://github.com/evil159) 
+  [#32](https://github.com/SwiftGen/templates/pull/32)
 
 ### Breaking Changes
 

--- a/Tests/Expected/Colors/default-context-customname.swift
+++ b/Tests/Expected/Colors/default-context-customname.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -61,3 +63,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/default-context-defaults.swift
+++ b/Tests/Expected/Colors/default-context-defaults.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -61,3 +63,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/default-context-empty.swift
+++ b/Tests/Expected/Colors/default-context-empty.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,5 +19,6 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // No color found

--- a/Tests/Expected/Colors/default-context-text-defaults.swift
+++ b/Tests/Expected/Colors/default-context-text-defaults.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -76,3 +78,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/rawValue-context-customname.swift
+++ b/Tests/Expected/Colors/rawValue-context-customname.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -48,3 +50,5 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/rawValue-context-defaults.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -48,3 +50,5 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/rawValue-context-empty.swift
+++ b/Tests/Expected/Colors/rawValue-context-empty.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,5 +19,6 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // No color found

--- a/Tests/Expected/Colors/swift3-context-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-customname.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -61,3 +63,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -61,3 +63,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/Tests/Expected/Colors/swift3-context-empty.swift
+++ b/Tests/Expected/Colors/swift3-context-empty.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,5 +19,6 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // No color found

--- a/Tests/Expected/Colors/swift3-context-text-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-text-defaults.swift
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
@@ -76,3 +78,5 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/templates/colors-default.stencil
+++ b/templates/colors-default.stencil
@@ -54,8 +54,8 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/templates/colors-default.stencil
+++ b/templates/colors-default.stencil
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 {% if colors %}
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
@@ -55,3 +57,5 @@ extension Color {
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/templates/colors-rawValue.stencil
+++ b/templates/colors-rawValue.stencil
@@ -44,8 +44,8 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/templates/colors-rawValue.stencil
+++ b/templates/colors-rawValue.stencil
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 {% if colors %}
 // swiftlint:disable file_length
@@ -45,3 +47,5 @@ extension Color {
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable file_length
+// swiftlint:enable line_length

--- a/templates/colors-swift3.stencil
+++ b/templates/colors-swift3.stencil
@@ -8,6 +8,7 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -18,6 +19,7 @@ extension Color {
     self.init(red: red, green: green, blue: blue, alpha: alpha)
   }
 }
+// swiftlint:enable operator_usage_whitespace
 
 {% if colors %}
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
@@ -55,3 +57,6 @@ extension Color {
 {% else %}
 // No color found
 {% endif %}
+// swiftlint:enable file_length
+// swiftlint:enable line_length
+

--- a/templates/colors-swift3.stencil
+++ b/templates/colors-swift3.stencil
@@ -54,9 +54,8 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
+// swiftlint:enable file_length
+// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}
-// swiftlint:enable file_length
-// swiftlint:enable line_length
-


### PR DESCRIPTION
There was inconsistency in `swiftlint` rules: `file_length`, and `line_length` were disabled but not enabled back(probably not a big deal, just a minor thing). 
Another thing was that vertical alignment of variables inside `Color` extension initialiser caused `swiftlint` to emit a warning based on `operator_usage_whitespace ` rule, fixed it by disabling this rule for the `Color` extension.