### PR TITLE
Disable SwiftLint `conditional_returns_on_newline` in font template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ _None_
   [David Jennes](https://github.com/djbe)
   [#24](https://github.com/SwiftGen/SwiftGenKit/issues/24)
 
+* Disable SwiftLint `conditional_returns_on_newline` in the font template.  
+  [Tom Baranes](https://github.com/tbaranes)
+  [#33](https://github.com/SwiftGen/templates/pull/33)
+
 ## 1.0.0
 
 _The templates tagged with this version are the ones embedded in SwiftGen 4.2._

--- a/Tests/Expected/Fonts/default-context-customname.swift
+++ b/Tests/Expected/Fonts/default-context-customname.swift
@@ -10,6 +10,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -10,6 +10,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!

--- a/Tests/Expected/Fonts/swift3-context-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-customname.swift
@@ -10,6 +10,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -10,6 +10,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!

--- a/templates/fonts-default.stencil
+++ b/templates/fonts-default.stencil
@@ -11,6 +11,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!

--- a/templates/fonts-swift3.stencil
+++ b/templates/fonts-swift3.stencil
@@ -11,6 +11,7 @@
 
 // swiftlint:disable file_length
 // swiftlint:disable line_length
+// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!


### PR DESCRIPTION
Otherwise, it generates a warning that will be pop again each time swiftgen's templates are updated.