### PR TITLE
fix missing segue module info

### DIFF
--- a/Contexts/Storyboards-macOS/all.plist
+++ b/Contexts/Storyboards-macOS/all.plist
@@ -162,6 +162,8 @@
 				<dict>
 					<key>customClass</key>
 					<string>FadeSegue</string>
+					<key>customModule</key>
+					<string>FadeSegue</string>
 					<key>identifier</key>
 					<string>public</string>
 				</dict>

--- a/Contexts/Storyboards-macOS/customname.plist
+++ b/Contexts/Storyboards-macOS/customname.plist
@@ -162,6 +162,8 @@
 				<dict>
 					<key>customClass</key>
 					<string>FadeSegue</string>
+					<key>customModule</key>
+					<string>FadeSegue</string>
 					<key>identifier</key>
 					<string>public</string>
 				</dict>

--- a/Contexts/Storyboards-macOS/messages.plist
+++ b/Contexts/Storyboards-macOS/messages.plist
@@ -118,6 +118,8 @@
 				<dict>
 					<key>customClass</key>
 					<string>FadeSegue</string>
+					<key>customModule</key>
+					<string>FadeSegue</string>
 					<key>identifier</key>
 					<string>public</string>
 				</dict>


### PR DESCRIPTION
Somehow stuff is broken, probably some merge gone wrong
related to: https://github.com/SwiftGen/SwiftGenKit/pull/26