### PR TITLE
Improve swiftlint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Bug Fixes
 
-_None_
+* Fixed `swiftlint` errors for the latest version.  
+  [David Jennes](https://github.com/djbe) 
+  [#46](https://github.com/SwiftGen/templates/pull/46)
 
 ### Breaking Changes
 

--- a/Tests/Expected/Colors/default-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/default-context-defaults-customname.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum XCTColors {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -56,6 +57,8 @@ enum XCTColors {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -63,5 +66,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/default-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/default-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/default-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/default-context-defaults-customname.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTColors {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -57,9 +55,7 @@ enum XCTColors {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: XCTColors) {

--- a/Tests/Expected/Colors/default-context-defaults.swift
+++ b/Tests/Expected/Colors/default-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/default-context-defaults.swift
+++ b/Tests/Expected/Colors/default-context-defaults.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -57,9 +55,7 @@ enum ColorName {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: ColorName) {

--- a/Tests/Expected/Colors/default-context-defaults.swift
+++ b/Tests/Expected/Colors/default-context-defaults.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -56,6 +57,8 @@ enum ColorName {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -63,5 +66,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/default-context-empty.swift
+++ b/Tests/Expected/Colors/default-context-empty.swift
@@ -1,24 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
-  import AppKit.NSColor
-  typealias Color = NSColor
-#endif
-
-// swiftlint:disable operator_usage_whitespace
-extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
-
 // No color found

--- a/Tests/Expected/Colors/default-context-text-defaults.swift
+++ b/Tests/Expected/Colors/default-context-text-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/default-context-text-defaults.swift
+++ b/Tests/Expected/Colors/default-context-text-defaults.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -71,6 +72,8 @@ enum ColorName {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -78,5 +81,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/default-context-text-defaults.swift
+++ b/Tests/Expected/Colors/default-context-text-defaults.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -72,9 +70,7 @@ enum ColorName {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: ColorName) {

--- a/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum XCTColors: UInt32 {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -43,6 +44,8 @@ enum XCTColors: UInt32 {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -50,5 +53,3 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults-customname.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTColors: UInt32 {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -44,9 +42,7 @@ enum XCTColors: UInt32 {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: XCTColors) {

--- a/Tests/Expected/Colors/rawValue-context-defaults.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/rawValue-context-defaults.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum ColorName: UInt32 {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -43,6 +44,8 @@ enum ColorName: UInt32 {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -50,5 +53,3 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/rawValue-context-defaults.swift
+++ b/Tests/Expected/Colors/rawValue-context-defaults.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum ColorName: UInt32 {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -44,9 +42,7 @@ enum ColorName: UInt32 {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: ColorName) {

--- a/Tests/Expected/Colors/rawValue-context-empty.swift
+++ b/Tests/Expected/Colors/rawValue-context-empty.swift
@@ -1,24 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
-  import AppKit.NSColor
-  typealias Color = NSColor
-#endif
-
-// swiftlint:disable operator_usage_whitespace
-extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
-
 // No color found

--- a/Tests/Expected/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults-customname.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum XCTColors {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -56,6 +57,8 @@ enum XCTColors {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -63,5 +66,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults-customname.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTColors {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -57,9 +55,7 @@ enum XCTColors {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: XCTColors) {

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -57,9 +55,7 @@ enum ColorName {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: ColorName) {

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -56,6 +57,8 @@ enum ColorName {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -63,5 +66,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/swift3-context-empty.swift
+++ b/Tests/Expected/Colors/swift3-context-empty.swift
@@ -1,24 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
-  import AppKit.NSColor
-  typealias Color = NSColor
-#endif
-
-// swiftlint:disable operator_usage_whitespace
-extension Color {
-  convenience init(rgbaValue: UInt32) {
-    let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
-    let green = CGFloat((rgbaValue >> 16) & 0xff) / 255.0
-    let blue  = CGFloat((rgbaValue >>  8) & 0xff) / 255.0
-    let alpha = CGFloat((rgbaValue      ) & 0xff) / 255.0
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
-}
-// swiftlint:enable operator_usage_whitespace
-
 // No color found

--- a/Tests/Expected/Colors/swift3-context-text-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-text-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Colors/swift3-context-text-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-text-defaults.swift
@@ -8,6 +8,8 @@
   typealias Color = NSColor
 #endif
 
+// swiftlint:disable file_length
+
 // swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
@@ -21,9 +23,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
@@ -71,6 +72,8 @@ enum ColorName {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -78,5 +81,3 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length

--- a/Tests/Expected/Colors/swift3-context-text-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-text-defaults.swift
@@ -23,9 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum ColorName {
   /// <span style="display:block;width:3em;height:2em;border:1px solid black;background:#339666"></span>
   /// Alpha: 100% <br/> (0x339666ff)
@@ -72,9 +70,7 @@ enum ColorName {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: ColorName) {

--- a/Tests/Expected/Fonts/default-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/default-context-defaults-customname.swift
@@ -50,9 +50,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay: String, FontConvertible {
     case Black = ".SFNSDisplay-Black"
@@ -86,8 +84,6 @@ enum CustomFamily {
     case Internal = "private"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/default-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/default-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Fonts/default-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/default-context-defaults-customname.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -25,7 +23,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
@@ -50,6 +50,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum CustomFamily {
   enum SFNSDisplay: String, FontConvertible {
     case Black = ".SFNSDisplay-Black"
@@ -83,5 +86,8 @@ enum CustomFamily {
     case Internal = "private"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -50,9 +50,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
     case Black = ".SFNSDisplay-Black"
@@ -86,8 +84,6 @@ enum FontFamily {
     case Internal = "private"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -25,7 +23,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
@@ -50,6 +50,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
     case Black = ".SFNSDisplay-Black"
@@ -83,5 +86,8 @@ enum FontFamily {
     case Internal = "private"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/default-context-defaults.swift
+++ b/Tests/Expected/Fonts/default-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -50,9 +50,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay: String, FontConvertible {
     case black = ".SFNSDisplay-Black"
@@ -86,8 +84,6 @@ enum CustomFamily {
     case `internal` = "private"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -25,7 +23,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
@@ -50,6 +50,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum CustomFamily {
   enum SFNSDisplay: String, FontConvertible {
     case black = ".SFNSDisplay-Black"
@@ -83,5 +86,8 @@ enum CustomFamily {
     case `internal` = "private"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -50,9 +50,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
     case black = ".SFNSDisplay-Black"
@@ -86,8 +84,6 @@ enum FontFamily {
     case `internal` = "private"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -25,7 +23,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
@@ -50,6 +50,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
     case black = ".SFNSDisplay-Black"
@@ -83,5 +86,8 @@ enum FontFamily {
     case `internal` = "private"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/allvalues-context-defaults-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults-customname.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTImages: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
@@ -23,6 +21,7 @@ enum XCTImages: String {
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
 
+  // swiftlint:disable:next explicit_type_interface
   static let allValues = [
     Exotic_Banana,
     Exotic_Mango,
@@ -34,9 +33,7 @@ enum XCTImages: String {
     Round_Tomato
   ]
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension XCTImages {
   var image: Image {

--- a/Tests/Expected/Images/allvalues-context-defaults-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults-customname.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTImages: String {
   case Exotic_Banana = "Exotic/Banana"
@@ -32,7 +33,12 @@ enum XCTImages: String {
     Round_Double_Cherry,
     Round_Tomato
   ]
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension XCTImages {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -46,7 +52,6 @@ enum XCTImages: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: XCTImages) {

--- a/Tests/Expected/Images/allvalues-context-defaults-customname.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum Asset: String {
   case Exotic_Banana = "Exotic/Banana"
@@ -32,7 +33,12 @@ enum Asset: String {
     Round_Double_Cherry,
     Round_Tomato
   ]
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension Asset {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -46,7 +52,6 @@ enum Asset: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: Asset) {

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum Asset: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
@@ -23,6 +21,7 @@ enum Asset: String {
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
 
+  // swiftlint:disable:next explicit_type_interface
   static let allValues = [
     Exotic_Banana,
     Exotic_Mango,
@@ -34,9 +33,7 @@ enum Asset: String {
     Round_Tomato
   ]
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Asset {
   var image: Image {

--- a/Tests/Expected/Images/allvalues-context-defaults.swift
+++ b/Tests/Expected/Images/allvalues-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/default-context-defaults-customname.swift
+++ b/Tests/Expected/Images/default-context-defaults-customname.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTImages: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
@@ -23,9 +21,7 @@ enum XCTImages: String {
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension XCTImages {
   var image: Image {

--- a/Tests/Expected/Images/default-context-defaults-customname.swift
+++ b/Tests/Expected/Images/default-context-defaults-customname.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTImages: String {
   case Exotic_Banana = "Exotic/Banana"
@@ -21,7 +22,12 @@ enum XCTImages: String {
   case Round_Apple = "Round/Apple"
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension XCTImages {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -35,7 +41,6 @@ enum XCTImages: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: XCTImages) {

--- a/Tests/Expected/Images/default-context-defaults-customname.swift
+++ b/Tests/Expected/Images/default-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum Asset: String {
   case Exotic_Banana = "Exotic/Banana"
@@ -21,7 +22,12 @@ enum Asset: String {
   case Round_Apple = "Round/Apple"
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension Asset {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -35,7 +41,6 @@ enum Asset: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: Asset) {

--- a/Tests/Expected/Images/default-context-defaults.swift
+++ b/Tests/Expected/Images/default-context-defaults.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum Asset: String {
   case Exotic_Banana = "Exotic/Banana"
   case Exotic_Mango = "Exotic/Mango"
@@ -23,9 +21,7 @@ enum Asset: String {
   case Round_Double_Cherry = "Round/Double/Cherry"
   case Round_Tomato = "Round/Tomato"
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Asset {
   var image: Image {

--- a/Tests/Expected/Images/dot-syntax-context-defaults-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/dot-syntax-context-defaults-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults-customname.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 struct XCTImagesType: StringLiteralConvertible {
   private var value: String
@@ -41,7 +39,7 @@ struct XCTImagesType: StringLiteralConvertible {
   }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum XCTImages {
   enum Exotic {
     static let Banana: XCTImagesType = "Exotic/Banana"
@@ -60,7 +58,7 @@ enum XCTImages {
     }
   }
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: XCTImagesType) {

--- a/Tests/Expected/Images/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 struct AssetType: StringLiteralConvertible {
   private var value: String
@@ -41,7 +39,7 @@ struct AssetType: StringLiteralConvertible {
   }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Exotic {
     static let Banana: AssetType = "Exotic/Banana"
@@ -60,7 +58,7 @@ enum Asset {
     }
   }
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: AssetType) {

--- a/Tests/Expected/Images/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults-customname.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 struct XCTImagesType: ExpressibleByStringLiteral {
   fileprivate var value: String
@@ -41,7 +39,7 @@ struct XCTImagesType: ExpressibleByStringLiteral {
   }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum XCTImages {
   enum Exotic {
     static let banana: XCTImagesType = "Exotic/Banana"
@@ -60,7 +58,7 @@ enum XCTImages {
     }
   }
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: XCTImagesType) {

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Images/dot-syntax-swift3-context-defaults.swift
@@ -9,8 +9,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 struct AssetType: ExpressibleByStringLiteral {
   fileprivate var value: String
@@ -41,7 +39,7 @@ struct AssetType: ExpressibleByStringLiteral {
   }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Exotic {
     static let banana: AssetType = "Exotic/Banana"
@@ -60,7 +58,7 @@ enum Asset {
     }
   }
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: AssetType) {

--- a/Tests/Expected/Images/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/swift3-context-defaults-customname.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTImages: String {
   case exoticBanana = "Exotic/Banana"
@@ -21,7 +22,12 @@ enum XCTImages: String {
   case roundApple = "Round/Apple"
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension XCTImages {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -35,7 +41,6 @@ enum XCTImages: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: XCTImages) {

--- a/Tests/Expected/Images/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/swift3-context-defaults-customname.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/swift3-context-defaults-customname.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTImages: String {
   case exoticBanana = "Exotic/Banana"
   case exoticMango = "Exotic/Mango"
@@ -23,9 +21,7 @@ enum XCTImages: String {
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension XCTImages {
   var image: Image {

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -9,8 +9,9 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum Asset: String {
   case exoticBanana = "Exotic/Banana"
@@ -21,7 +22,12 @@ enum Asset: String {
   case roundApple = "Round/Apple"
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension Asset {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -35,7 +41,6 @@ enum Asset: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: Asset) {

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -10,9 +10,7 @@
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum Asset: String {
   case exoticBanana = "Exotic/Banana"
   case exoticMango = "Exotic/Mango"
@@ -23,9 +21,7 @@ enum Asset: String {
   case roundDoubleCherry = "Round/Double/Cherry"
   case roundTomato = "Round/Tomato"
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Asset {
   var image: Image {

--- a/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-customname.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker

--- a/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
@@ -6,8 +6,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -43,6 +41,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -182,5 +184,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all-ignore-module.swift
@@ -42,10 +42,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -185,9 +182,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-all.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/default-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import UIKit
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-customname.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
@@ -6,8 +6,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -43,6 +41,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -182,5 +184,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all-ignore-module.swift
@@ -42,10 +42,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -185,9 +182,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-all.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/lowercase-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import UIKit
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum XCTStoryboardsSegue {
     case showPassword = "ShowPassword"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum XCTStoryboardsSegue {
     case showPassword = "ShowPassword"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
@@ -42,10 +42,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -185,9 +182,6 @@ enum StoryboardSegue {
     case showPassword = "ShowPassword"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
@@ -6,8 +6,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -43,6 +41,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -182,5 +184,9 @@ enum StoryboardSegue {
     case showPassword = "ShowPassword"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum StoryboardSegue {
     case showPassword = "ShowPassword"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum StoryboardSegue {
     case showPassword = "ShowPassword"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import UIKit
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-customname.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum XCTStoryboardsSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
@@ -6,8 +6,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -43,6 +41,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -182,5 +184,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all-ignore-module.swift
@@ -42,10 +42,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -185,9 +182,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
@@ -43,10 +43,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -186,9 +183,6 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
@@ -7,8 +7,6 @@ import LocationPicker
 import SlackTextViewController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -44,6 +42,10 @@ extension UIViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -183,5 +185,9 @@ enum StoryboardSegue {
     case ShowPassword
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-all.swift
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue

--- a/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-iOS/uppercase-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import UIKit
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-customname.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import PrefsWindowController
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
@@ -5,8 +5,6 @@ import Cocoa
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -49,6 +47,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -167,5 +169,9 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all-ignore-module.swift
@@ -48,10 +48,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -170,9 +167,6 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-all.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/default-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/default-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import Cocoa
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum XCTStoryboardsSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-customname.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import PrefsWindowController
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
@@ -5,8 +5,6 @@ import Cocoa
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -49,6 +47,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -167,5 +169,9 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all-ignore-module.swift
@@ -48,10 +48,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -170,9 +167,6 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-all.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum StoryboardSegue {
     case Public = "public"
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/lowercase-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import Cocoa
-
 // No storyboard found

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum XCTStoryboardsSegue {
     case `public`
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum XCTStoryboardsSegue {
     case `public`
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
@@ -48,10 +48,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -170,9 +167,6 @@ enum StoryboardSegue {
     case `public`
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import PrefsWindowController
 
 // swiftlint:disable file_length

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
@@ -5,8 +5,6 @@ import Cocoa
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -49,6 +47,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -167,5 +169,9 @@ enum StoryboardSegue {
     case `public`
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -49,10 +49,7 @@ extension NSViewController {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -171,9 +168,6 @@ enum StoryboardSegue {
     case `public`
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -1,7 +1,8 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
+// swiftlint:disable sorted_imports
 import Cocoa
+import Foundation
 import FadeSegue
 import PrefsWindowController
 

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -6,8 +6,6 @@ import FadeSegue
 import PrefsWindowController
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 protocol StoryboardSceneType {
   static var storyboardName: String { get }
@@ -50,6 +48,10 @@ extension NSViewController {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 enum StoryboardScene {
   enum AdditionalImport: String, StoryboardSceneType {
     static let storyboardName = "AdditionalImport"
@@ -168,5 +170,9 @@ enum StoryboardSegue {
     case `public`
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}

--- a/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-empty.swift
@@ -1,6 +1,3 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-import Foundation
-import Cocoa
-
 // No storyboard found

--- a/Tests/Expected/Strings/default-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/default-context-defaults-customname.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   case AlertMessage
@@ -67,9 +65,7 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/default-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/default-context-defaults-customname.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTLoc {
   /// Some alert body there
@@ -30,7 +31,6 @@ enum XCTLoc {
   /// User Profile Settings
   case SettingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension XCTLoc: CustomStringConvertible {
   var description: String { return self.string }
@@ -67,6 +67,9 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/default-context-defaults.swift
+++ b/Tests/Expected/Strings/default-context-defaults.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum L10n {
   /// Some alert body there
@@ -30,7 +31,6 @@ enum L10n {
   /// User Profile Settings
   case SettingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension L10n: CustomStringConvertible {
   var description: String { return self.string }
@@ -67,6 +67,9 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/default-context-defaults.swift
+++ b/Tests/Expected/Strings/default-context-defaults.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   case AlertMessage
@@ -67,9 +65,7 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/dot-syntax-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-defaults-customname.swift
@@ -4,11 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("alert_message")
@@ -89,11 +85,7 @@ enum XCTLoc {
     }
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
 extension XCTLoc {
   private static func tr(key: String, _ args: CVarArgType...) -> String {

--- a/Tests/Expected/Strings/dot-syntax-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-defaults-customname.swift
@@ -3,14 +3,12 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
+// swiftlint:disable type_body_length
 // swiftlint:disable type_name
-
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("alert_message")
@@ -91,6 +89,11 @@ enum XCTLoc {
     }
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 extension XCTLoc {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
@@ -100,8 +103,3 @@ extension XCTLoc {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs

--- a/Tests/Expected/Strings/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-defaults.swift
@@ -3,14 +3,12 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
+// swiftlint:disable type_body_length
 // swiftlint:disable type_name
-
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("alert_message")
@@ -91,6 +89,11 @@ enum L10n {
     }
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 extension L10n {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
@@ -100,8 +103,3 @@ extension L10n {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs

--- a/Tests/Expected/Strings/dot-syntax-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-context-defaults.swift
@@ -4,11 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("alert_message")
@@ -89,11 +85,7 @@ enum L10n {
     }
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
 extension L10n {
   private static func tr(key: String, _ args: CVarArgType...) -> String {

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-defaults-customname.swift
@@ -3,14 +3,12 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
+// swiftlint:disable type_body_length
 // swiftlint:disable type_name
-
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("alert_message")
@@ -91,6 +89,11 @@ enum XCTLoc {
     }
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 extension XCTLoc {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
@@ -100,8 +103,3 @@ extension XCTLoc {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-defaults-customname.swift
@@ -4,11 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("alert_message")
@@ -89,11 +85,7 @@ enum XCTLoc {
     }
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
 extension XCTLoc {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
@@ -3,14 +3,12 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
+// swiftlint:disable type_body_length
 // swiftlint:disable type_name
-
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("alert_message")
@@ -91,6 +89,11 @@ enum L10n {
     }
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 extension L10n {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
@@ -100,8 +103,3 @@ extension L10n {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs

--- a/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/dot-syntax-swift3-context-defaults.swift
@@ -4,11 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("alert_message")
@@ -89,11 +85,7 @@ enum L10n {
     }
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
 extension L10n {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {

--- a/Tests/Expected/Strings/genstrings-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/genstrings-context-defaults-customname.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   case AlertMessage
@@ -77,9 +75,7 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/genstrings-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/genstrings-context-defaults-customname.swift
@@ -2,8 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable line_length
+// swiftlint:disable file_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum XCTLoc {
   /// Some alert body there
   case AlertMessage
@@ -74,6 +77,9 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/genstrings-context-defaults.swift
+++ b/Tests/Expected/Strings/genstrings-context-defaults.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   case AlertMessage
@@ -77,9 +75,7 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/genstrings-context-defaults.swift
+++ b/Tests/Expected/Strings/genstrings-context-defaults.swift
@@ -2,8 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable line_length
+// swiftlint:disable file_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum L10n {
   /// Some alert body there
   case AlertMessage
@@ -74,6 +77,9 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/no-comments-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-defaults-customname.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTLoc {
   case alertMessage
@@ -19,7 +20,6 @@ enum XCTLoc {
   case seTTingsUSerProFileSectioNFooterText
   case settingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension XCTLoc: CustomStringConvertible {
   var description: String { return self.string }
@@ -56,6 +56,9 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/no-comments-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-defaults-customname.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   case alertMessage
   case alertTitle
@@ -56,9 +54,7 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum L10n {
   case alertMessage
@@ -19,7 +20,6 @@ enum L10n {
   case seTTingsUSerProFileSectioNFooterText
   case settingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension L10n: CustomStringConvertible {
   var description: String { return self.string }
@@ -56,6 +56,9 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/no-comments-swift3-context-defaults.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   case alertMessage
   case alertTitle
@@ -56,9 +54,7 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/structured-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/structured-context-defaults-customname.swift
@@ -3,11 +3,11 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-
+// swiftlint:disable type_body_length
 enum XCTLoc {
   /// Some alert body there
   case AlertMessage
@@ -196,9 +196,10 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable nesting
+// swiftlint:enable type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/structured-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/structured-context-defaults-customname.swift
@@ -4,10 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length
 enum XCTLoc {
   /// Some alert body there
   case AlertMessage
@@ -196,10 +193,7 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length
 
 func tr(key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/structured-context-defaults.swift
+++ b/Tests/Expected/Strings/structured-context-defaults.swift
@@ -3,11 +3,11 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-
+// swiftlint:disable type_body_length
 enum L10n {
   /// Some alert body there
   case AlertMessage
@@ -196,9 +196,10 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable nesting
+// swiftlint:enable type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/structured-context-defaults.swift
+++ b/Tests/Expected/Strings/structured-context-defaults.swift
@@ -4,10 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length
 enum L10n {
   /// Some alert body there
   case AlertMessage
@@ -196,10 +193,7 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length
 
 func tr(key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/swift3-context-defaults-customname.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   case alertMessage
@@ -67,9 +65,7 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Strings/swift3-context-defaults-customname.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum XCTLoc {
   /// Some alert body there
@@ -30,7 +31,6 @@ enum XCTLoc {
   /// User Profile Settings
   case settingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension XCTLoc: CustomStringConvertible {
   var description: String { return self.string }
@@ -67,6 +67,9 @@ extension XCTLoc: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: XCTLoc) -> String {
   return key.string

--- a/Tests/Expected/Strings/swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/swift3-context-defaults.swift
@@ -4,9 +4,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   case alertMessage
@@ -67,9 +65,7 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: L10n) -> String {
   return key.string

--- a/Tests/Expected/Strings/swift3-context-defaults.swift
+++ b/Tests/Expected/Strings/swift3-context-defaults.swift
@@ -3,8 +3,9 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 enum L10n {
   /// Some alert body there
@@ -30,7 +31,6 @@ enum L10n {
   /// User Profile Settings
   case settingsUserProfileSectionHeaderTitle
 }
-// swiftlint:enable type_body_length
 
 extension L10n: CustomStringConvertible {
   var description: String { return self.string }
@@ -67,6 +67,9 @@ extension L10n: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: L10n) -> String {
   return key.string

--- a/Tests/TemplatesTests/TestsHelper.swift
+++ b/Tests/TemplatesTests/TestsHelper.swift
@@ -24,11 +24,9 @@ func diff(_ result: String, _ expected: String) -> String? {
   let lhsLines = result.components(separatedBy: nl)
   let rhsLines = expected.components(separatedBy: nl)
 
-  for (idx, pair) in zip(lhsLines, rhsLines).enumerated() {
-    if pair.0 != pair.1 {
-      firstDiff = idx
-      break
-    }
+  for (idx, pair) in zip(lhsLines, rhsLines).enumerated() where pair.0 != pair.1 {
+    firstDiff = idx
+    break
   }
   if firstDiff == nil && lhsLines.count != rhsLines.count {
     firstDiff = min(lhsLines.count, rhsLines.count)

--- a/rakelib/lint.rake
+++ b/rakelib/lint.rake
@@ -6,7 +6,7 @@ namespace :lint do
   task :install do |task|
     next if system('which swiftlint > /dev/null')
 
-    url = 'https://github.com/realm/SwiftLint/releases/download/0.16.1/SwiftLint.pkg'
+    url = 'https://github.com/realm/SwiftLint/releases/download/0.18.1/SwiftLint.pkg'
     tmppath = '/tmp/SwiftLint.pkg'
 
     Utils.run([

--- a/templates/colors/default.stencil
+++ b/templates/colors/default.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if colors %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/templates/colors/default.stencil
+++ b/templates/colors/default.stencil
@@ -25,9 +25,7 @@ extension Color {
 // swiftlint:enable operator_usage_whitespace
 
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 enum {{enumName}} {
   {% for color in colors %}
@@ -49,9 +47,7 @@ enum {{enumName}} {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: {{enumName}}) {

--- a/templates/colors/default.stencil
+++ b/templates/colors/default.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if colors %}
 #if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
@@ -7,6 +8,8 @@
   import AppKit.NSColor
   typealias Color = NSColor
 #endif
+
+// swiftlint:disable file_length
 
 // swiftlint:disable operator_usage_whitespace
 extension Color {
@@ -21,11 +24,9 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-{% if colors %}
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 enum {{enumName}} {
@@ -48,6 +49,8 @@ enum {{enumName}} {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -55,8 +58,6 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}

--- a/templates/colors/rawValue.stencil
+++ b/templates/colors/rawValue.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if colors %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/templates/colors/rawValue.stencil
+++ b/templates/colors/rawValue.stencil
@@ -24,9 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"|swiftIdentifier}}{% endset %}
 enum {{enumName}}: UInt32 {
   {% for color in colors %}
@@ -39,9 +37,7 @@ enum {{enumName}}: UInt32 {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: {{enumName}}) {

--- a/templates/colors/rawValue.stencil
+++ b/templates/colors/rawValue.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if colors %}
 #if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
@@ -7,6 +8,8 @@
   import AppKit.NSColor
   typealias Color = NSColor
 #endif
+
+// swiftlint:disable file_length
 
 // swiftlint:disable operator_usage_whitespace
 extension Color {
@@ -21,10 +24,8 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-{% if colors %}
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"|swiftIdentifier}}{% endset %}
 enum {{enumName}}: UInt32 {
@@ -38,6 +39,8 @@ enum {{enumName}}: UInt32 {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -45,8 +48,6 @@ extension Color {
     self.init(rgbaValue: name.rawValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if colors %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIColor
-  typealias Color = UIColor
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSColor
   typealias Color = NSColor
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIColor
+  typealias Color = UIColor
 #endif
 
 // swiftlint:disable file_length

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -25,9 +25,7 @@ extension Color {
 // swiftlint:enable operator_usage_whitespace
 
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 enum {{enumName}} {
   {% for color in colors %}
@@ -49,9 +47,7 @@ enum {{enumName}} {
     return Color(named: self)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension Color {
   convenience init(named name: {{enumName}}) {

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if colors %}
 #if os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIColor
   typealias Color = UIColor
@@ -7,6 +8,8 @@
   import AppKit.NSColor
   typealias Color = NSColor
 #endif
+
+// swiftlint:disable file_length
 
 // swiftlint:disable operator_usage_whitespace
 extension Color {
@@ -21,11 +24,9 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-{% if colors %}
 {# Note: We don't use a UInt32 rawValue in this template so we can have multiple colors with the same rgbaValue #}
-// swiftlint:disable file_length
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 enum {{enumName}} {
@@ -48,6 +49,8 @@ enum {{enumName}} {
     return Color(named: self)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable type_body_length
 
 extension Color {
@@ -55,8 +58,6 @@ extension Color {
     self.init(rgbaValue: name.rgbaValue)
   }
 }
-// swiftlint:enable file_length
-// swiftlint:enable line_length
 {% else %}
 // No color found
 {% endif %}

--- a/templates/fonts/default.stencil
+++ b/templates/fonts/default.stencil
@@ -10,8 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -26,7 +24,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
@@ -51,6 +51,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix|escapeReservedKeywords}}: String, FontConvertible {
@@ -60,6 +63,9 @@ enum {{param.enumName|default:"FontFamily"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/fonts/default.stencil
+++ b/templates/fonts/default.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if families %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/templates/fonts/default.stencil
+++ b/templates/fonts/default.stencil
@@ -51,9 +51,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix|escapeReservedKeywords}}: String, FontConvertible {
@@ -63,9 +61,7 @@ enum {{param.enumName|default:"FontFamily"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -10,8 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable conditional_returns_on_newline
 
 protocol FontConvertible {
   func font(size: CGFloat) -> Font!
@@ -26,7 +24,9 @@ extension FontConvertible where Self: RawRepresentable, Self.RawValue == String 
     let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else { return }
+    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+      return
+    }
 
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
@@ -51,6 +51,9 @@ extension Font {
   }
 }
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix|escapeReservedKeywords}}: String, FontConvertible {
@@ -60,6 +63,9 @@ enum {{param.enumName|default:"FontFamily"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if families %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIFont
-  typealias Font = UIFont
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSFont
   typealias Font = NSFont
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIFont
+  typealias Font = UIFont
 #endif
 
 // swiftlint:disable file_length

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -51,9 +51,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
   enum {{family.name|swiftIdentifier|snakeToCamelCaseNoPrefix|escapeReservedKeywords}}: String, FontConvertible {
@@ -63,9 +61,7 @@ enum {{param.enumName|default:"FontFamily"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 private final class BundleToken {}
 {% else %}

--- a/templates/images/allvalues.stencil
+++ b/templates/images/allvalues.stencil
@@ -10,7 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveCaseBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -30,6 +29,8 @@
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
@@ -42,7 +43,12 @@ enum {{enumName}}: String {
     {% call recursiveValueBlock catalog.assets false %}
     {% endfor %}
   ]
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension {{enumName}} {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -56,7 +62,6 @@ enum {{enumName}}: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: {{enumName}}) {

--- a/templates/images/allvalues.stencil
+++ b/templates/images/allvalues.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if images %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/templates/images/allvalues.stencil
+++ b/templates/images/allvalues.stencil
@@ -29,24 +29,21 @@
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveCaseBlock catalog.assets %}
   {% endfor %}
 
+  // swiftlint:disable:next explicit_type_interface
   static let allValues = [
     {% for catalog in catalogs %}
     {% call recursiveValueBlock catalog.assets false %}
     {% endfor %}
   ]
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension {{enumName}} {
   var image: Image {

--- a/templates/images/default.stencil
+++ b/templates/images/default.stencil
@@ -20,18 +20,14 @@
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension {{enumName}} {
   var image: Image {

--- a/templates/images/default.stencil
+++ b/templates/images/default.stencil
@@ -10,7 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -21,13 +20,20 @@
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension {{enumName}} {
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -41,7 +47,6 @@ enum {{enumName}}: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: {{enumName}}) {

--- a/templates/images/default.stencil
+++ b/templates/images/default.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if images %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/templates/images/dot-syntax-swift3.stencil
+++ b/templates/images/dot-syntax-swift3.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/templates/images/dot-syntax-swift3.stencil
+++ b/templates/images/dot-syntax-swift3.stencil
@@ -10,8 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 struct {{enumName}}Type: ExpressibleByStringLiteral {
@@ -55,7 +53,7 @@ struct {{enumName}}Type: ExpressibleByStringLiteral {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}
@@ -67,7 +65,7 @@ enum {{enumName}} {
   {% call recursiveBlock catalogs.first.assets "" %}
   {% endif %}
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: {{enumName}}Type) {

--- a/templates/images/dot-syntax.stencil
+++ b/templates/images/dot-syntax.stencil
@@ -10,8 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable nesting
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 struct {{enumName}}Type: StringLiteralConvertible {
@@ -55,7 +53,7 @@ struct {{enumName}}Type: StringLiteralConvertible {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}
@@ -67,7 +65,7 @@ enum {{enumName}} {
   {% call recursiveBlock catalogs.first.assets "" %}
   {% endif %}
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
 
 extension Image {
   convenience init!(asset: {{enumName}}Type) {

--- a/templates/images/dot-syntax.stencil
+++ b/templates/images/dot-syntax.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if catalogs %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/templates/images/swift3.stencil
+++ b/templates/images/swift3.stencil
@@ -10,7 +10,6 @@
 #endif
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveBlock images %}
   {% for image in images %}
   {% if not image.items %}
@@ -21,13 +20,20 @@
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
+}
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
+extension {{enumName}} {
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)
     #if os(iOS) || os(tvOS)
@@ -41,7 +47,6 @@ enum {{enumName}}: String {
     return result
   }
 }
-// swiftlint:enable type_body_length
 
 extension Image {
   convenience init!(asset: {{enumName}}) {

--- a/templates/images/swift3.stencil
+++ b/templates/images/swift3.stencil
@@ -20,18 +20,14 @@
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 enum {{enumName}}: String {
   {% for catalog in catalogs %}
   {% call recursiveBlock catalog.assets %}
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 extension {{enumName}} {
   var image: Image {

--- a/templates/images/swift3.stencil
+++ b/templates/images/swift3.stencil
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if images %}
-#if os(iOS) || os(tvOS) || os(watchOS)
-  import UIKit.UIImage
-  typealias Image = UIImage
-#elseif os(OSX)
+#if os(OSX)
   import AppKit.NSImage
   typealias Image = NSImage
+#elseif os(iOS) || os(tvOS) || os(watchOS)
+  import UIKit.UIImage
+  typealias Image = UIImage
 #endif
 
 // swiftlint:disable file_length

--- a/templates/storyboards/default.stencil
+++ b/templates/storyboards/default.stencil
@@ -1,6 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit

--- a/templates/storyboards/default.stencil
+++ b/templates/storyboards/default.stencil
@@ -47,10 +47,7 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -116,10 +113,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/default.stencil
+++ b/templates/storyboards/default.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit
@@ -7,10 +8,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -48,6 +46,10 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -113,6 +115,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/lowercase.stencil
+++ b/templates/storyboards/lowercase.stencil
@@ -1,6 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit

--- a/templates/storyboards/lowercase.stencil
+++ b/templates/storyboards/lowercase.stencil
@@ -47,10 +47,7 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -116,10 +113,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/lowercase.stencil
+++ b/templates/storyboards/lowercase.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit
@@ -7,10 +8,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -48,6 +46,10 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -113,6 +115,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-default.stencil
+++ b/templates/storyboards/osx-default.stencil
@@ -54,10 +54,7 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -97,10 +94,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-default.stencil
+++ b/templates/storyboards/osx-default.stencil
@@ -1,9 +1,10 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
-import Foundation
 import Cocoa
+import Foundation
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}

--- a/templates/storyboards/osx-default.stencil
+++ b/templates/storyboards/osx-default.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import Cocoa
@@ -7,10 +8,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -55,6 +53,10 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -94,6 +96,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-lowercase.stencil
+++ b/templates/storyboards/osx-lowercase.stencil
@@ -54,10 +54,7 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -97,10 +94,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-lowercase.stencil
+++ b/templates/storyboards/osx-lowercase.stencil
@@ -1,9 +1,10 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
-import Foundation
 import Cocoa
+import Foundation
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}

--- a/templates/storyboards/osx-lowercase.stencil
+++ b/templates/storyboards/osx-lowercase.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import Cocoa
@@ -7,10 +8,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -55,6 +53,10 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -94,6 +96,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-swift3.stencil
+++ b/templates/storyboards/osx-swift3.stencil
@@ -54,10 +54,7 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -97,10 +94,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/osx-swift3.stencil
+++ b/templates/storyboards/osx-swift3.stencil
@@ -1,9 +1,10 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
-import Foundation
 import Cocoa
+import Foundation
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}

--- a/templates/storyboards/osx-swift3.stencil
+++ b/templates/storyboards/osx-swift3.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}NS{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import Cocoa
@@ -7,10 +8,7 @@ import Cocoa
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -55,6 +53,10 @@ extension NSViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -94,6 +96,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/swift3.stencil
+++ b/templates/storyboards/swift3.stencil
@@ -1,6 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit

--- a/templates/storyboards/swift3.stencil
+++ b/templates/storyboards/swift3.stencil
@@ -47,10 +47,7 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -116,10 +113,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/swift3.stencil
+++ b/templates/storyboards/swift3.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit
@@ -7,10 +8,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -48,6 +46,10 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -113,6 +115,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/uppercase.stencil
+++ b/templates/storyboards/uppercase.stencil
@@ -1,6 +1,7 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
 {% if storyboards %}
+// swiftlint:disable sorted_imports
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit

--- a/templates/storyboards/uppercase.stencil
+++ b/templates/storyboards/uppercase.stencil
@@ -47,10 +47,7 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -116,10 +113,7 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length type_body_length type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/storyboards/uppercase.stencil
+++ b/templates/storyboards/uppercase.stencil
@@ -1,5 +1,6 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
+{% if storyboards %}
 {% macro className scene %}{% if scene.customClass %}{% if scene.customModule %}{{scene.customModule}}.{% endif %}{{scene.customClass}}{% else %}UI{{scene.baseType}}{% endif %}{% endmacro %}
 import Foundation
 import UIKit
@@ -7,10 +8,7 @@ import UIKit
 import {{module}}
 {% endfor %}
 
-{% if storyboards %}
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardSceneType {
@@ -48,6 +46,10 @@ extension UIViewController {
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 enum {{sceneEnumName}} {
   {% for storyboard in storyboards %}
@@ -113,6 +115,10 @@ enum {{param.segueEnumName|default:"StoryboardSegue"}} {
   }
   {% endfor %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 private final class BundleToken {}
 {% else %}

--- a/templates/strings/default.stencil
+++ b/templates/strings/default.stencil
@@ -14,9 +14,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
@@ -52,9 +50,7 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/default.stencil
+++ b/templates/strings/default.stencil
@@ -4,7 +4,6 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveBlock item %}
   {% for string in item.strings %}
   /// {{string.translation}}
@@ -15,12 +14,13 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
 }
-// swiftlint:enable type_body_length
 
 {% macro parametersBlock types %}{% for type in types %}let p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro argumentsBlock types %}{% for type in types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -52,6 +52,9 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/dot-syntax-swift3.stencil
+++ b/templates/strings/dot-syntax-swift3.stencil
@@ -4,13 +4,6 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
-// swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
-// swiftlint:disable type_name
 {% macro parametersBlock types %}{% for type in types %}_ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro argumentsBlock types %}{% for type in types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro recursiveBlock item sp %}
@@ -33,10 +26,20 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable nesting
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels sp %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 extension {{enumName}} {
@@ -47,11 +50,6 @@ extension {{enumName}} {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings/dot-syntax-swift3.stencil
+++ b/templates/strings/dot-syntax-swift3.stencil
@@ -26,22 +26,13 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels sp %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
-{% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 extension {{enumName}} {
   fileprivate static func tr(_ key: String, _ args: CVarArg...) -> String {
     let format = NSLocalizedString(key, bundle: Bundle(for: BundleToken.self), comment: "")

--- a/templates/strings/dot-syntax.stencil
+++ b/templates/strings/dot-syntax.stencil
@@ -4,13 +4,6 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
-// swiftlint:disable nesting
-// swiftlint:disable variable_name
-// swiftlint:disable valid_docs
-// swiftlint:disable type_name
 {% macro parametersBlock types %}{% for type in types %}p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro argumentsBlock types %}{% for type in types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro recursiveBlock item sp %}
@@ -33,10 +26,20 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable nesting
+// swiftlint:disable type_body_length
+// swiftlint:disable type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels sp %}
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable nesting
+// swiftlint:enable type_body_length
+// swiftlint:enable type_name
 
 extension {{enumName}} {
   private static func tr(key: String, _ args: CVarArgType...) -> String {
@@ -46,11 +49,6 @@ extension {{enumName}} {
 }
 
 private final class BundleToken {}
-
-// swiftlint:enable type_body_length
-// swiftlint:enable nesting
-// swiftlint:enable variable_name
-// swiftlint:enable valid_docs
 {% else %}
 // No string found
 {% endif %}

--- a/templates/strings/dot-syntax.stencil
+++ b/templates/strings/dot-syntax.stencil
@@ -26,20 +26,12 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
-// swiftlint:disable type_name
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels sp %}
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
-// swiftlint:enable type_name
+// swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 
 extension {{enumName}} {
   private static func tr(key: String, _ args: CVarArgType...) -> String {

--- a/templates/strings/genstrings.stencil
+++ b/templates/strings/genstrings.stencil
@@ -14,9 +14,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock structuredStrings %}
@@ -53,9 +51,7 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/genstrings.stencil
+++ b/templates/strings/genstrings.stencil
@@ -3,7 +3,7 @@
 {% if tables.first.levels %}
 import Foundation
 
-// swiftlint:disable line_length
+// swiftlint:disable file_length
 {% macro recursiveBlock item %}
   {% for string in item.strings %}
   /// {{string.translation}}
@@ -14,6 +14,9 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock structuredStrings %}
@@ -50,6 +53,9 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/no-comments-swift3.stencil
+++ b/templates/strings/no-comments-swift3.stencil
@@ -13,9 +13,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
@@ -51,9 +49,7 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/no-comments-swift3.stencil
+++ b/templates/strings/no-comments-swift3.stencil
@@ -4,7 +4,6 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveBlock item %}
   {% for string in item.strings %}
   case {{string.key|swiftIdentifier|snakeToCamelCase|lowerFirstWord|escapeReservedKeywords}}{% if string.types %}({{string.types|join}}){% endif %}
@@ -14,12 +13,13 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
 }
-// swiftlint:enable type_body_length
 
 {% macro parametersBlock types %}{% for type in types %}let p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro argumentsBlock types %}{% for type in types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -51,6 +51,9 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/structured.stencil
+++ b/templates/strings/structured.stencil
@@ -5,10 +5,7 @@ import Foundation
 
 // swiftlint:disable file_length
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable nesting
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length nesting type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
 {% macro enumBlock item sp %}
@@ -65,10 +62,7 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable nesting
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length nesting type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/structured.stencil
+++ b/templates/strings/structured.stencil
@@ -4,11 +4,11 @@
 import Foundation
 
 // swiftlint:disable file_length
+
+// swiftlint:disable identifier_name
 // swiftlint:disable line_length
-
-// swiftlint:disable type_body_length
 // swiftlint:disable nesting
-
+// swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
 {% macro enumBlock item sp %}
@@ -65,9 +65,10 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: NSLocale.currentLocale(), arguments: args)
   }
 }
-
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
 // swiftlint:enable nesting
+// swiftlint:enable type_body_length
 
 func tr(key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/swift3.stencil
+++ b/templates/strings/swift3.stencil
@@ -4,7 +4,6 @@
 import Foundation
 
 // swiftlint:disable file_length
-// swiftlint:disable line_length
 {% macro recursiveBlock item %}
   {% for string in item.strings %}
   /// {{string.translation}}
@@ -15,12 +14,13 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
+// swiftlint:disable identifier_name
+// swiftlint:disable line_length
 // swiftlint:disable type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
 }
-// swiftlint:enable type_body_length
 
 {% macro parametersBlock types %}{% for type in types %}let p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
 {% macro argumentsBlock types %}{% for type in types %}p{{forloop.counter}}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
@@ -52,6 +52,9 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
+// swiftlint:enable identifier_name
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 
 func tr(_ key: {{enumName}}) -> String {
   return key.string

--- a/templates/strings/swift3.stencil
+++ b/templates/strings/swift3.stencil
@@ -14,9 +14,7 @@ import Foundation
   {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% call recursiveBlock tables.first.levels %}
@@ -52,9 +50,7 @@ extension {{enumName}}: CustomStringConvertible {
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }
-// swiftlint:enable identifier_name
-// swiftlint:enable line_length
-// swiftlint:enable type_body_length
+// swiftlint:enable identifier_name line_length type_body_length
 
 func tr(_ key: {{enumName}}) -> String {
   return key.string


### PR DESCRIPTION
Continuation of #35

Currently, the latest `swiftlint` version has a few issues with our output files. While we're at it, we might as well review the disable/enable rules we're using in the templates.

- Disable `file_length` for the whole file
- Disable `identifier_name` for generated identifiers (all swift versions, they can still be too short or long in swift 3)
- Disable `type_body_length` for generated types
- Disable `line_length` for generated lines
- Disable `nesting` for generated deep types (dot syntax)
- Disable `type_name` for generated types (dot syntax and storyboards)
- Enable all disabled rules directly after the generated bits
- Remove `valid_docs` as it doesn't exist anymore and has been opt-in for a while
- Remove `variable_name` as it's been replaced by `identifier_name`