### PR TITLE
Fixture change for SwiftGenKit#18

### DIFF
--- a/Fixtures/Colors/bad-syntax.xml
+++ b/Fixtures/Colors/bad-syntax.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <>
-  <color name="ArticleTitle">#33fe66</color>
+  <color>#33fe66</color>
 </resources>


### PR DESCRIPTION
Small change to trigger bad syntax error for colors xml parser.
Related to https://github.com/SwiftGen/SwiftGenKit/pull/18.