### PR TITLE
Deprecate swift2 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 * Many deprecated templates have been removed, and others have been renamed to reflect new behaviours. We've prepared a migration guide which you can find here: [Documentation/MigrationGuide](https://github.com/SwiftGen/templates/blob/master/Documentation/MigrationGuide.md).  
   [David Jennes](https://github.com/djbe)
   [#47](https://github.com/SwiftGen/templates/issues/47)
+* Since Swift 2 is no longer actively supported, we now consider those templates as "legacy" and cannot guarantee that there won't be issues with the generated code.  
+  [David Jennes](https://github.com/djbe)
+  [#53](https://github.com/SwiftGen/templates/issues/53)
 
 ### New Features
 

--- a/Documentation/colors/swift2.md
+++ b/Documentation/colors/swift2.md
@@ -11,6 +11,7 @@
 
 - When you need to generate *Swift 2* code
 - Supports _multiple_ color names with the _same_ value
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Documentation/fonts/swift2.md
+++ b/Documentation/fonts/swift2.md
@@ -10,6 +10,7 @@
 ## When to use it
 
 - When you need to generate *Swift 2* code
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Documentation/images/swift2.md
+++ b/Documentation/images/swift2.md
@@ -10,6 +10,7 @@
 ## When to use it
 
 - When you need to generate *Swift 2* code
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 It also takes into account any namespacing folder in your Assets Catalogs (i.e. if you create a folder in your Assets Catalog, select it, and check the "Provides Namespace" checkbox on the Attributes Inspector panel on the right)
 

--- a/Documentation/storyboards/macOS-swift2.md
+++ b/Documentation/storyboards/macOS-swift2.md
@@ -11,6 +11,7 @@
 
 - When you need to generate *Swift 2* code
 - You want to generate code for AppKit platforms (macOS).
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Documentation/storyboards/swift2.md
+++ b/Documentation/storyboards/swift2.md
@@ -11,6 +11,7 @@
 
 - When you need to generate *Swift 2* code
 - You want to generate code for UIKit platforms (iOS, tvOS and watchOS)
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Documentation/strings/flat-swift2.md
+++ b/Documentation/strings/flat-swift2.md
@@ -11,6 +11,7 @@
 
 - When you need to generate *Swift 2* code
 - If you use unstructured key names for your strings, or a structure that we don't support (yet). If you use "dot-syntax" keys, please check out the [dot-syntax](dot-syntax.md) template.
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Documentation/strings/structured-swift2.md
+++ b/Documentation/strings/structured-swift2.md
@@ -17,6 +17,7 @@
 "some.deep.something"
 "hello.world"
 ```
+- **Warning**: Swift 2 is no longer actively supported, so we cannot guarantee that there won't be issues with the generated code.
 
 ## Customization
 

--- a/Rakefile
+++ b/Rakefile
@@ -20,10 +20,6 @@ SDKS = {
   :appletvos => 'arm64-apple-tvos10.0'
 }
 TOOLCHAINS = {
-  :swift2 => {
-    :module_path => "#{MODULE_OUTPUT_PATH}/swift2.3",
-    :toolchain => 'com.apple.dt.toolchain.Swift_2_3'
-  },
   :swift3 => {
     :module_path => "#{MODULE_OUTPUT_PATH}/swift3",
     :toolchain => 'com.apple.dt.toolchain.XcodeDefault'
@@ -81,7 +77,8 @@ namespace :output do
     if f.match('swift3')
       toolchain = TOOLCHAINS[:swift3]
     else
-      toolchain = TOOLCHAINS[:swift2]
+      puts "Unable to typecheck Swift 2 file #{f}"
+      return true
     end
 
     if f.match('iOS')

--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,7 @@ namespace :output do
     end
 
     commands = sdks.map do |sdk|
-      %Q(--toolchain #{toolchain[:toolchain]} -sdk #{sdk} swiftc -parse -target #{SDKS[sdk]} -I #{toolchain[:module_path]} "#{MODULE_OUTPUT_PATH}/Definitions.swift" #{f})
+      %Q(--toolchain #{toolchain[:toolchain]} -sdk #{sdk} swiftc -typecheck -target #{SDKS[sdk]} -I #{toolchain[:module_path]} "#{MODULE_OUTPUT_PATH}/Definitions.swift" #{f})
     end
     subtask = File.basename(f, '.*')
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   xcode:
-    version: 8.2
+    version: 8.3
+  pre:
+  - sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
 
 dependencies:
   post:


### PR DESCRIPTION
Xcode 8.3 dropped support for swift 2.3, so we can no longer compile the output code from those templates. We'll keep the swift 2 templates for now, but no longer check them for compile issues.