### PR TITLE
Fonts refactor to use constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Images: fixed issue with catalogs that have an empty folder.  
   [David Jennes](https://github.com/djbe) 
   [#51](https://github.com/SwiftGen/templates/pull/51)
+* Fonts: fixed font registration mechanism, which was broken in some situations.  
+  [David Jennes](https://github.com/djbe) 
+  [#58](https://github.com/SwiftGen/templates/pull/58)
 
 ### Breaking Changes
 

--- a/Documentation/fonts/swift2.md
+++ b/Documentation/fonts/swift2.md
@@ -27,10 +27,10 @@ You can customize some elements of this template by overriding the following par
 ```swift
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
-    case Regular = ".SFNSDisplay-Regular"
+    static let Regular = FontConvertible(".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
   enum ZapfDingbats: String, FontConvertible {
-    case Regular = "ZapfDingbatsITC"
+    static let Regular = FontConvertible("ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
 }
 ```

--- a/Documentation/fonts/swift2.md
+++ b/Documentation/fonts/swift2.md
@@ -26,10 +26,13 @@ You can customize some elements of this template by overriding the following par
 
 ```swift
 enum FontFamily {
-  enum SFNSDisplay: String, FontConvertible {
+  enum SFNSDisplay {
+    static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let Bold = FontConvertible(".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let Heavy = FontConvertible(".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
     static let Regular = FontConvertible(".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum ZapfDingbats: String, FontConvertible {
+  enum ZapfDingbats {
     static let Regular = FontConvertible("ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
 }

--- a/Documentation/fonts/swift3.md
+++ b/Documentation/fonts/swift3.md
@@ -26,10 +26,10 @@ You can customize some elements of this template by overriding the following par
 ```swift
 enum FontFamily {
   enum SFNSDisplay: String, FontConvertible {
-    case regular = ".SFNSDisplay-Regular"
+    static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
   enum ZapfDingbats: String, FontConvertible {
-    case regular = "ZapfDingbatsITC"
+    static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
 }
 ```

--- a/Documentation/fonts/swift3.md
+++ b/Documentation/fonts/swift3.md
@@ -25,10 +25,13 @@ You can customize some elements of this template by overriding the following par
 
 ```swift
 enum FontFamily {
-  enum SFNSDisplay: String, FontConvertible {
+  enum SFNSDisplay {
+    static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
     static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum ZapfDingbats: String, FontConvertible {
+  enum ZapfDingbats {
     static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
 }

--- a/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
@@ -10,78 +10,75 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.URLForResource(path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible
-    where FontType: RawRepresentable, FontType.RawValue == String>
-    (font: FontType, size: CGFloat) {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
-  enum SFNSDisplay: String, FontConvertible {
-    case Black = ".SFNSDisplay-Black"
-    case Bold = ".SFNSDisplay-Bold"
-    case Heavy = ".SFNSDisplay-Heavy"
-    case Regular = ".SFNSDisplay-Regular"
+  enum SFNSDisplay {
+    static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let Bold = FontConvertible(".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let Heavy = FontConvertible(".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    static let Regular = FontConvertible(".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum SFNSText: String, FontConvertible {
-    case Bold = ".SFNSText-Bold"
-    case Heavy = ".SFNSText-Heavy"
-    case Regular = ".SFNSText-Regular"
+  enum SFNSText {
+    static let Bold = FontConvertible(".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    static let Heavy = FontConvertible(".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    static let Regular = FontConvertible(".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
   }
-  enum Avenir: String, FontConvertible {
-    case Black = "Avenir-Black"
-    case BlackOblique = "Avenir-BlackOblique"
-    case Book = "Avenir-Book"
-    case BookOblique = "Avenir-BookOblique"
-    case Heavy = "Avenir-Heavy"
-    case HeavyOblique = "Avenir-HeavyOblique"
-    case Light = "Avenir-Light"
-    case LightOblique = "Avenir-LightOblique"
-    case Medium = "Avenir-Medium"
-    case MediumOblique = "Avenir-MediumOblique"
-    case Oblique = "Avenir-Oblique"
-    case Roman = "Avenir-Roman"
+  enum Avenir {
+    static let Black = FontConvertible("Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    static let BlackOblique = FontConvertible("Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Book = FontConvertible("Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    static let BookOblique = FontConvertible("Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Heavy = FontConvertible("Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    static let HeavyOblique = FontConvertible("Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Light = FontConvertible("Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    static let LightOblique = FontConvertible("Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Medium = FontConvertible("Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    static let MediumOblique = FontConvertible("Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Oblique = FontConvertible("Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    static let Roman = FontConvertible("Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
   }
-  enum ZapfDingbats: String, FontConvertible {
-    case Regular = "ZapfDingbatsITC"
+  enum ZapfDingbats {
+    static let Regular = FontConvertible("ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
-  enum Public: String, FontConvertible {
-    case Internal = "private"
+  enum Public {
+    static let Internal = FontConvertible("private", family: "public", path: "class.ttf")
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Expected/Fonts/swift2-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults.swift
@@ -10,78 +10,75 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.URLForResource(path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible
-    where FontType: RawRepresentable, FontType.RawValue == String>
-    (font: FontType, size: CGFloat) {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
-  enum SFNSDisplay: String, FontConvertible {
-    case Black = ".SFNSDisplay-Black"
-    case Bold = ".SFNSDisplay-Bold"
-    case Heavy = ".SFNSDisplay-Heavy"
-    case Regular = ".SFNSDisplay-Regular"
+  enum SFNSDisplay {
+    static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let Bold = FontConvertible(".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let Heavy = FontConvertible(".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    static let Regular = FontConvertible(".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum SFNSText: String, FontConvertible {
-    case Bold = ".SFNSText-Bold"
-    case Heavy = ".SFNSText-Heavy"
-    case Regular = ".SFNSText-Regular"
+  enum SFNSText {
+    static let Bold = FontConvertible(".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    static let Heavy = FontConvertible(".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    static let Regular = FontConvertible(".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
   }
-  enum Avenir: String, FontConvertible {
-    case Black = "Avenir-Black"
-    case BlackOblique = "Avenir-BlackOblique"
-    case Book = "Avenir-Book"
-    case BookOblique = "Avenir-BookOblique"
-    case Heavy = "Avenir-Heavy"
-    case HeavyOblique = "Avenir-HeavyOblique"
-    case Light = "Avenir-Light"
-    case LightOblique = "Avenir-LightOblique"
-    case Medium = "Avenir-Medium"
-    case MediumOblique = "Avenir-MediumOblique"
-    case Oblique = "Avenir-Oblique"
-    case Roman = "Avenir-Roman"
+  enum Avenir {
+    static let Black = FontConvertible("Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    static let BlackOblique = FontConvertible("Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Book = FontConvertible("Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    static let BookOblique = FontConvertible("Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Heavy = FontConvertible("Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    static let HeavyOblique = FontConvertible("Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Light = FontConvertible("Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    static let LightOblique = FontConvertible("Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Medium = FontConvertible("Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    static let MediumOblique = FontConvertible("Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    static let Oblique = FontConvertible("Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    static let Roman = FontConvertible("Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
   }
-  enum ZapfDingbats: String, FontConvertible {
-    case Regular = "ZapfDingbatsITC"
+  enum ZapfDingbats {
+    static let Regular = FontConvertible("ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
-  enum Public: String, FontConvertible {
-    case Internal = "private"
+  enum Public {
+    static let Internal = FontConvertible("private", family: "public", path: "class.ttf")
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -10,78 +10,75 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.url(forResource: path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible>
-    (font: FontType, size: CGFloat)
-    where FontType: RawRepresentable, FontType.RawValue == String {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
-  enum SFNSDisplay: String, FontConvertible {
-    case black = ".SFNSDisplay-Black"
-    case bold = ".SFNSDisplay-Bold"
-    case heavy = ".SFNSDisplay-Heavy"
-    case regular = ".SFNSDisplay-Regular"
+  enum SFNSDisplay {
+    static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum SFNSText: String, FontConvertible {
-    case bold = ".SFNSText-Bold"
-    case heavy = ".SFNSText-Heavy"
-    case regular = ".SFNSText-Regular"
+  enum SFNSText {
+    static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
   }
-  enum Avenir: String, FontConvertible {
-    case black = "Avenir-Black"
-    case blackOblique = "Avenir-BlackOblique"
-    case book = "Avenir-Book"
-    case bookOblique = "Avenir-BookOblique"
-    case heavy = "Avenir-Heavy"
-    case heavyOblique = "Avenir-HeavyOblique"
-    case light = "Avenir-Light"
-    case lightOblique = "Avenir-LightOblique"
-    case medium = "Avenir-Medium"
-    case mediumOblique = "Avenir-MediumOblique"
-    case oblique = "Avenir-Oblique"
-    case roman = "Avenir-Roman"
+  enum Avenir {
+    static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
   }
-  enum ZapfDingbats: String, FontConvertible {
-    case regular = "ZapfDingbatsITC"
+  enum ZapfDingbats {
+    static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
-  enum Public: String, FontConvertible {
-    case `internal` = "private"
+  enum Public {
+    static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -10,78 +10,75 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.url(forResource: path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible>
-    (font: FontType, size: CGFloat)
-    where FontType: RawRepresentable, FontType.RawValue == String {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
-  enum SFNSDisplay: String, FontConvertible {
-    case black = ".SFNSDisplay-Black"
-    case bold = ".SFNSDisplay-Bold"
-    case heavy = ".SFNSDisplay-Heavy"
-    case regular = ".SFNSDisplay-Regular"
+  enum SFNSDisplay {
+    static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")
+    static let bold = FontConvertible(name: ".SFNSDisplay-Bold", family: ".SF NS Display", path: "SFNSDisplay-Bold.otf")
+    static let heavy = FontConvertible(name: ".SFNSDisplay-Heavy", family: ".SF NS Display", path: "SFNSDisplay-Heavy.otf")
+    static let regular = FontConvertible(name: ".SFNSDisplay-Regular", family: ".SF NS Display", path: "SFNSDisplay-Regular.otf")
   }
-  enum SFNSText: String, FontConvertible {
-    case bold = ".SFNSText-Bold"
-    case heavy = ".SFNSText-Heavy"
-    case regular = ".SFNSText-Regular"
+  enum SFNSText {
+    static let bold = FontConvertible(name: ".SFNSText-Bold", family: ".SF NS Text", path: "SFNSText-Bold.otf")
+    static let heavy = FontConvertible(name: ".SFNSText-Heavy", family: ".SF NS Text", path: "SFNSText-Heavy.otf")
+    static let regular = FontConvertible(name: ".SFNSText-Regular", family: ".SF NS Text", path: "SFNSText-Regular.otf")
   }
-  enum Avenir: String, FontConvertible {
-    case black = "Avenir-Black"
-    case blackOblique = "Avenir-BlackOblique"
-    case book = "Avenir-Book"
-    case bookOblique = "Avenir-BookOblique"
-    case heavy = "Avenir-Heavy"
-    case heavyOblique = "Avenir-HeavyOblique"
-    case light = "Avenir-Light"
-    case lightOblique = "Avenir-LightOblique"
-    case medium = "Avenir-Medium"
-    case mediumOblique = "Avenir-MediumOblique"
-    case oblique = "Avenir-Oblique"
-    case roman = "Avenir-Roman"
+  enum Avenir {
+    static let black = FontConvertible(name: "Avenir-Black", family: "Avenir", path: "Avenir.ttc")
+    static let blackOblique = FontConvertible(name: "Avenir-BlackOblique", family: "Avenir", path: "Avenir.ttc")
+    static let book = FontConvertible(name: "Avenir-Book", family: "Avenir", path: "Avenir.ttc")
+    static let bookOblique = FontConvertible(name: "Avenir-BookOblique", family: "Avenir", path: "Avenir.ttc")
+    static let heavy = FontConvertible(name: "Avenir-Heavy", family: "Avenir", path: "Avenir.ttc")
+    static let heavyOblique = FontConvertible(name: "Avenir-HeavyOblique", family: "Avenir", path: "Avenir.ttc")
+    static let light = FontConvertible(name: "Avenir-Light", family: "Avenir", path: "Avenir.ttc")
+    static let lightOblique = FontConvertible(name: "Avenir-LightOblique", family: "Avenir", path: "Avenir.ttc")
+    static let medium = FontConvertible(name: "Avenir-Medium", family: "Avenir", path: "Avenir.ttc")
+    static let mediumOblique = FontConvertible(name: "Avenir-MediumOblique", family: "Avenir", path: "Avenir.ttc")
+    static let oblique = FontConvertible(name: "Avenir-Oblique", family: "Avenir", path: "Avenir.ttc")
+    static let roman = FontConvertible(name: "Avenir-Roman", family: "Avenir", path: "Avenir.ttc")
   }
-  enum ZapfDingbats: String, FontConvertible {
-    case regular = "ZapfDingbatsITC"
+  enum ZapfDingbats {
+    static let regular = FontConvertible(name: "ZapfDingbatsITC", family: "Zapf Dingbats", path: "ZapfDingbats.ttf")
   }
-  enum Public: String, FontConvertible {
-    case `internal` = "private"
+  enum Public {
+    static let `internal` = FontConvertible(name: "private", family: "public", path: "class.ttf")
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/templates/fonts/swift2.stencil
+++ b/templates/fonts/swift2.stencil
@@ -11,52 +11,49 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = NSBundle(forClass: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.URLForResource(rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.URLForResource(path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .None, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible
-    where FontType: RawRepresentable, FontType.RawValue == String>
-    (font: FontType, size: CGFloat) {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNamesForFamilyName(font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
-  enum {{family.name|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}}: String, FontConvertible {
+  enum {{family.name|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}} {
     {% for font in family.fonts %}
-    case {{font.style|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}} = "{{font.name}}"
+    static let {{font.style|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}} = FontConvertible("{{font.name}}", family: "{{family.name}}", path: "{{font.path}}")
     {% endfor %}
   }
   {% endfor %}

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -11,52 +11,49 @@
 
 // swiftlint:disable file_length
 
-protocol FontConvertible {
-  func font(size: CGFloat) -> Font!
-}
+struct FontConvertible {
+  let name: String
+  let family: String
+  let path: String
 
-extension FontConvertible where Self: RawRepresentable, Self.RawValue == String {
   func font(size: CGFloat) -> Font! {
     return Font(font: self, size: size)
   }
 
   func register() {
-    let extensions = ["otf", "ttf"]
     let bundle = Bundle(for: BundleToken.self)
 
-    guard let url = extensions.flatMap({ bundle.url(forResource: rawValue, withExtension: $0) }).first else {
+    guard let url = bundle.url(forResource: path, withExtension: nil) else {
       return
     }
 
     var errorRef: Unmanaged<CFError>?
-    CTFontManagerRegisterFontsForURL(url as CFURL, .none, &errorRef)
+    CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
   }
 }
 
 extension Font {
-  convenience init!<FontType: FontConvertible>
-    (font: FontType, size: CGFloat)
-    where FontType: RawRepresentable, FontType.RawValue == String {
-      #if os(iOS) || os(tvOS) || os(watchOS)
-      if UIFont.fontNames(forFamilyName: font.rawValue).isEmpty {
-        font.register()
-      }
-      #elseif os(OSX)
-      if NSFontManager.shared().availableMembers(ofFontFamily: font.rawValue) == nil {
-        font.register()
-      }
-      #endif
+  convenience init!(font: FontConvertible, size: CGFloat) {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+      font.register()
+    }
+    #elseif os(OSX)
+    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+      font.register()
+    }
+    #endif
 
-      self.init(name: font.rawValue, size: size)
+    self.init(name: font.name, size: size)
   }
 }
 
 // swiftlint:disable identifier_name line_length type_body_length
 enum {{param.enumName|default:"FontFamily"}} {
   {% for family in families %}
-  enum {{family.name|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}}: String, FontConvertible {
+  enum {{family.name|swiftIdentifier|snakeToCamelCase:"true"|escapeReservedKeywords}} {
     {% for font in family.fonts %}
-    case {{font.style|swiftIdentifier|snakeToCamelCase:"true"|lowerFirstWord|escapeReservedKeywords}} = "{{font.name}}"
+    static let {{font.style|swiftIdentifier|snakeToCamelCase:"true"|lowerFirstWord|escapeReservedKeywords}} = FontConvertible(name: "{{font.name}}", family: "{{family.name}}", path: "{{font.path}}")
     {% endfor %}
   }
   {% endfor %}


### PR DESCRIPTION
Refactored the generated code to use `static let` constants instead of cases, as there is no real use case to want to enumerate over a font name.

There were also some issues with the font registration mechanism, which was broken if:
- the font file had a different name than the font name
- a different extension than "ttf" or "otf"

The fonts were also always re-registered if the font name was different from the font family name. We now directly use the path we receive from the parser, and match using the font family name from the parser.