### PR TITLE
Disable SwiftLint `redundant_string_enum_value`  in Images templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 
 ### Internal Changes
 
+* Disable SwiftLint `redundant_string_enum_value` in the images template.  
+  [Tom Baranes](https://github.com/tbaranes)
+  [#61](https://github.com/SwiftGen/templates/pull/61)
 * Switch from Travis CI to Circle CI, clean up the Rakefile in the process.  
   [David Jennes](https://github.com/djbe)
   [#24](https://github.com/SwiftGen/SwiftGenKit/issues/24)

--- a/Tests/Expected/Images/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Images/swift2-context-defaults-customname.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct XCTImagesType: StringLiteralConvertible {
   private var value: String

--- a/Tests/Expected/Images/swift2-context-defaults-no-all-values.swift
+++ b/Tests/Expected/Images/swift2-context-defaults-no-all-values.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct AssetType: StringLiteralConvertible {
   private var value: String

--- a/Tests/Expected/Images/swift2-context-defaults.swift
+++ b/Tests/Expected/Images/swift2-context-defaults.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct AssetType: StringLiteralConvertible {
   private var value: String

--- a/Tests/Expected/Images/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Images/swift3-context-defaults-customname.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct XCTImagesType: ExpressibleByStringLiteral {
   fileprivate var value: String

--- a/Tests/Expected/Images/swift3-context-defaults-no-all-values.swift
+++ b/Tests/Expected/Images/swift3-context-defaults-no-all-values.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct AssetType: ExpressibleByStringLiteral {
   fileprivate var value: String

--- a/Tests/Expected/Images/swift3-context-defaults.swift
+++ b/Tests/Expected/Images/swift3-context-defaults.swift
@@ -9,6 +9,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 struct AssetType: ExpressibleByStringLiteral {
   fileprivate var value: String

--- a/templates/images/swift2.stencil
+++ b/templates/images/swift2.stencil
@@ -10,6 +10,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 struct {{enumName}}Type: StringLiteralConvertible {

--- a/templates/images/swift3.stencil
+++ b/templates/images/swift3.stencil
@@ -10,6 +10,7 @@
 #endif
 
 // swiftlint:disable file_length
+// swiftlint:disable redundant_string_enum_value
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 struct {{enumName}}Type: ExpressibleByStringLiteral {


### PR DESCRIPTION
In a few cases, the template generated may trigger `redundant_string_enum_value ` warnings, for example:

```
// swiftlint:disable file_length
// swiftlint:disable line_length

// swiftlint:disable type_body_length
enum Asset: String {
  case logo = "logo"
...
```

Another solution would be to update the template in order to remove the rawValue when the enum key is the same, but it would be a bigger change, so I think this solution is enough for now.