### PR TITLE
XCAssets: added explicit type to allValues array

### DIFF
--- a/Tests/Expected/XCAssets/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/XCAssets/swift2-context-defaults-customname.swift
@@ -58,7 +58,7 @@ enum XCTImages {
     }
   }
 
-  static let allValues = [
+  static let allValues: [XCTImagesType] = [
     Exotic.Banana,
     Exotic.Mango,
     Private,

--- a/Tests/Expected/XCAssets/swift2-context-defaults.swift
+++ b/Tests/Expected/XCAssets/swift2-context-defaults.swift
@@ -58,7 +58,7 @@ enum Asset {
     }
   }
 
-  static let allValues = [
+  static let allValues: [AssetType] = [
     Exotic.Banana,
     Exotic.Mango,
     Private,

--- a/Tests/Expected/XCAssets/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/XCAssets/swift3-context-defaults-customname.swift
@@ -58,7 +58,7 @@ enum XCTImages {
     }
   }
 
-  static let allValues = [
+  static let allValues: [XCTImagesType] = [
     Exotic.banana,
     Exotic.mango,
     `private`,

--- a/Tests/Expected/XCAssets/swift3-context-defaults.swift
+++ b/Tests/Expected/XCAssets/swift3-context-defaults.swift
@@ -58,7 +58,7 @@ enum Asset {
     }
   }
 
-  static let allValues = [
+  static let allValues: [AssetType] = [
     Exotic.banana,
     Exotic.mango,
     `private`,

--- a/templates/xcassets/swift2.stencil
+++ b/templates/xcassets/swift2.stencil
@@ -44,7 +44,7 @@ struct {{enumName}}Type: StringLiteralConvertible {
 {{sp}}  {% call casesBlock images sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  static let allValues = [
+{{sp}}  static let allValues: [{{enumName}}Type] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock images "" false sp2 %}
 {{sp}}  ]

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -44,7 +44,7 @@ struct {{enumName}}Type: ExpressibleByStringLiteral {
 {{sp}}  {% call casesBlock images sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  static let allValues = [
+{{sp}}  static let allValues: [{{enumName}}Type] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock images "" false sp2 %}
 {{sp}}  ]


### PR DESCRIPTION
After updating to `SwiftGen 5.0`, one of my targets started complaining about this:
<img width="454" alt="screen shot 2017-08-15 at 3 37 13 pm" src="https://user-images.githubusercontent.com/685609/29339593-c4e3e992-81cf-11e7-8dfd-45a5a7529b0c.png">