### PR TITLE
Fonts: fix code which checks if a font is already registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-* Fix code which checks is font already registered.
+* Fonts: fix code which checks if a font is already registered.  
   [Vladimir Burdukov](https://github.com/chipp)
   [#77](https://github.com/SwiftGen/templates/pull/77)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ---
 
+## Master
+
+### Bug Fixes
+
+* Fix code which checks is font already registered.
+  [Vladimir Burdukov](https://github.com/chipp)
+  [#77](https://github.com/SwiftGen/templates/pull/77)
+
+### Breaking Changes
+
+_None_
+
+### New Features
+
+_None_
+
+### Internal Changes
+
+_None_
+
 ## 2.1.1
 
 ### Bug Fixes

--- a/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = NSBundle(forClass: BundleToken.self)
-
-    guard let url = bundle.URLForResource(path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
+  }
+
+  fileprivate var url: NSURL? {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+    if !UIFont.fontNamesForFamilyName(font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .None {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: NSURL? {
     let bundle = NSBundle(forClass: BundleToken.self)
-    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
-    return url
+    return bundle.URLForResource(path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = NSBundle(forClass: BundleToken.self)
-
-    guard let url = bundle.URLForResource(path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
+  }
+
+  fileprivate var url: NSURL? {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+    if !UIFont.fontNamesForFamilyName(font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .None {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: NSURL? {
     let bundle = NSBundle(forClass: BundleToken.self)
-    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
-    return url
+    return bundle.URLForResource(path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift2-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = NSBundle(forClass: BundleToken.self)
-
-    guard let url = bundle.URLForResource(path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
+  }
+
+  fileprivate var url: NSURL? {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+    if !UIFont.fontNamesForFamilyName(font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .None {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift2-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: NSURL? {
     let bundle = NSBundle(forClass: BundleToken.self)
-    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
-    return url
+    return bundle.URLForResource(path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared.availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared.availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/Tests/Expected/Fonts/swift4-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults.swift
@@ -27,8 +27,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/Tests/Expected/Fonts/swift4-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults.swift
@@ -20,25 +20,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared.availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/templates/fonts/swift2.stencil
+++ b/templates/fonts/swift2.stencil
@@ -21,25 +21,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = NSBundle(forClass: BundleToken.self)
-
-    guard let url = bundle.URLForResource(path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .Process, &errorRef)
+  }
+
+  fileprivate var url: NSURL? {
+    let bundle = NSBundle(forClass: BundleToken.self)
+    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNamesForFamilyName(font.family).isEmpty {
+    if !UIFont.fontNamesForFamilyName(font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.sharedFontManager().availableMembersOfFontFamily(font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .None {
       font.register()
     }
     #endif

--- a/templates/fonts/swift2.stencil
+++ b/templates/fonts/swift2.stencil
@@ -28,8 +28,7 @@ struct FontConvertible {
 
   fileprivate var url: NSURL? {
     let bundle = NSBundle(forClass: BundleToken.self)
-    guard let url = bundle.URLForResource(path, withExtension: nil) else { return nil }
-    return url
+    return bundle.URLForResource(path, withExtension: nil)
   }
 }
 

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -21,25 +21,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared().availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -28,8 +28,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -28,8 +28,7 @@ struct FontConvertible {
 
   fileprivate var url: URL? {
     let bundle = Bundle(for: BundleToken.self)
-    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
-    return url
+    return bundle.url(forResource: path, withExtension: nil)
   }
 }
 

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -21,25 +21,26 @@ struct FontConvertible {
   }
 
   func register() {
-    let bundle = Bundle(for: BundleToken.self)
-
-    guard let url = bundle.url(forResource: path, withExtension: nil) else {
-      return
-    }
-
+    guard let url = url else { return }
     var errorRef: Unmanaged<CFError>?
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, &errorRef)
+  }
+
+  fileprivate var url: URL? {
+    let bundle = Bundle(for: BundleToken.self)
+    guard let url = bundle.url(forResource: path, withExtension: nil) else { return nil }
+    return url
   }
 }
 
 extension Font {
   convenience init!(font: FontConvertible, size: CGFloat) {
     #if os(iOS) || os(tvOS) || os(watchOS)
-    if UIFont.fontNames(forFamilyName: font.family).isEmpty {
+    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
       font.register()
     }
     #elseif os(OSX)
-    if NSFontManager.shared.availableMembers(ofFontFamily: font.family) == nil {
+    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
       font.register()
     }
     #endif


### PR DESCRIPTION
@AliSoftware we discussed these changes here https://github.com/SwiftGen/templates/commit/06bcd2a8528f3e00bb389692a30d9862fdb15ef9#diff-3fc62affc2b681781b6ef4a2fac1a6e7R37

Also I prepared test project for these changes: https://github.com/chipp/FontTests

I tried to reuse `NSFontManager.shared().availableMembers(ofFontFamily:)` solution for macOS, but with help of test project I found that `NSFontManager` doesn't see freshly added fonts and this check is useless.