### PR TITLE
Fix link to generated XCAssets example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Fonts: fix code which checks if a font is already registered.  
   [Vladimir Burdukov](https://github.com/chipp)
   [#77](https://github.com/SwiftGen/templates/pull/77)
+* Documentation: Fix link to generated XCAssets example.  
+  [Alvar Hansen](https://github.com/allu22)
+  [#80](https://github.com/SwiftGen/templates/pull/80)
 
 ### Breaking Changes
 

--- a/Documentation/xcassets/swift2.md
+++ b/Documentation/xcassets/swift2.md
@@ -44,7 +44,7 @@ enum Asset {
 }
 ```
 
-[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift2-context-defaults.swift)
+[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift2-context-all.swift)
 
 ## Usage example
 

--- a/Documentation/xcassets/swift3.md
+++ b/Documentation/xcassets/swift3.md
@@ -44,7 +44,7 @@ enum Asset {
 }
 ```
 
-[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift3-context-defaults.swift)
+[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift3-context-all.swift)
 
 ## Usage example
 

--- a/Documentation/xcassets/swift4.md
+++ b/Documentation/xcassets/swift4.md
@@ -44,7 +44,7 @@ enum Asset {
 }
 ```
 
-[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift4-context-defaults.swift)
+[Full generated code](https://github.com/SwiftGen/templates/blob/master/Tests/Expected/XCAssets/swift4-context-all.swift)
 
 ## Usage example
 


### PR DESCRIPTION
As of bf58bf381efea31013f6ceae67aada4f4109a464, [`Documentation/xcassets/swift2.md`](https://github.com/SwiftGen/templates/blob/master/Documentation/xcassets/swift2.md), [`Documentation/xcassets/swift3.md`](https://github.com/SwiftGen/templates/blob/master/Documentation/xcassets/swift3.md) and [`Documentation/xcassets/swift4.md`](https://github.com/SwiftGen/templates/blob/master/Documentation/xcassets/swift4.md) have broken links to "Full generated code".


This pull request will update XCAssets fully generated code example links:
`swift2-context-defaults.swift` -> `swift2-context-all.swift`
`swift3-context-defaults.swift` -> `swift3-context-all.swift`
`swift4-context-defaults.swift` -> `swift4-context-all.swift`