### PR TITLE
Add `superfluous_disable_command` SwiftLint exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * Documentation: Fix link to generated XCAssets example.  
   [Alvar Hansen](https://github.com/allu22)
   [#80](https://github.com/SwiftGen/templates/pull/80)
+* SwiftLint rules: Disabled the `superfluous_disable_command` rule
+  for all `swiftlint:disable` exceptions in all templates.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [SwiftGen/SwiftGen#334](https://github.com/SwiftGen/SwiftGen/issues/334)
+  [#83](https://github.com/SwiftGen/templates/pull/83)
 
 ### Breaking Changes
 

--- a/Tests/Expected/Colors/literals-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-defaults-customname.swift
@@ -7,9 +7,10 @@
   import UIKit
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-defaults-customname.swift
@@ -7,9 +7,9 @@
   import UIKit
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-defaults.swift
@@ -8,9 +8,9 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-defaults.swift
@@ -8,9 +8,10 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift3-context-multiple.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-multiple.swift
@@ -8,9 +8,9 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension ColorName {
   enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Expected/Colors/literals-swift3-context-multiple.swift
+++ b/Tests/Expected/Colors/literals-swift3-context-multiple.swift
@@ -8,9 +8,10 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension ColorName {
   enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Expected/Colors/literals-swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-defaults-customname.swift
@@ -7,9 +7,10 @@
   import UIKit
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-defaults-customname.swift
@@ -7,9 +7,9 @@
   import UIKit
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension UIColor {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift4-context-defaults.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-defaults.swift
@@ -8,9 +8,9 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift4-context-defaults.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-defaults.swift
@@ -8,9 +8,10 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension ColorName {
   /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)
   static let articleBody = #colorLiteral(red: 0.2, green: 0.588235, blue: 0.4, alpha: 1.0)

--- a/Tests/Expected/Colors/literals-swift4-context-multiple.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-multiple.swift
@@ -8,9 +8,9 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension ColorName {
   enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Expected/Colors/literals-swift4-context-multiple.swift
+++ b/Tests/Expected/Colors/literals-swift4-context-multiple.swift
@@ -8,9 +8,10 @@
   enum ColorName { }
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension ColorName {
   enum Colors {
     /// 0x339666ff (r: 51, g: 150, b: 102, a: 255)

--- a/Tests/Expected/Colors/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift2-context-defaults-customname.swift
@@ -8,9 +8,10 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift2-context-defaults-customname.swift
@@ -8,9 +8,9 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift2-context-defaults.swift
+++ b/Tests/Expected/Colors/swift2-context-defaults.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift2-context-defaults.swift
+++ b/Tests/Expected/Colors/swift2-context-defaults.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift2-context-multiple.swift
+++ b/Tests/Expected/Colors/swift2-context-multiple.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift2-context-multiple.swift
+++ b/Tests/Expected/Colors/swift2-context-multiple.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults-customname.swift
@@ -8,9 +8,10 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults-customname.swift
@@ -8,9 +8,9 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift3-context-defaults.swift
+++ b/Tests/Expected/Colors/swift3-context-defaults.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift3-context-multiple.swift
+++ b/Tests/Expected/Colors/swift3-context-multiple.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift3-context-multiple.swift
+++ b/Tests/Expected/Colors/swift3-context-multiple.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift4-context-defaults-customname.swift
@@ -8,9 +8,10 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Colors/swift4-context-defaults-customname.swift
@@ -8,9 +8,9 @@
   typealias XCTColor = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension XCTColor {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension XCTColor {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct XCTColors {
   let rgbaValue: UInt32
   var color: XCTColor { return XCTColor(named: self) }

--- a/Tests/Expected/Colors/swift4-context-defaults.swift
+++ b/Tests/Expected/Colors/swift4-context-defaults.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift4-context-defaults.swift
+++ b/Tests/Expected/Colors/swift4-context-defaults.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift4-context-multiple.swift
+++ b/Tests/Expected/Colors/swift4-context-multiple.swift
@@ -8,9 +8,9 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +23,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Colors/swift4-context-multiple.swift
+++ b/Tests/Expected/Colors/swift4-context-multiple.swift
@@ -8,9 +8,10 @@
   typealias Color = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension Color {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -23,7 +24,7 @@ extension Color {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 struct ColorName {
   let rgbaValue: UInt32
   var color: Color { return Color(named: self) }

--- a/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-customname.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults-preservepath.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift2-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift2-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift2-context-defaults.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let Black = FontConvertible(".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-customname.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults-preservepath.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift3-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift3-context-defaults.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-customname.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum CustomFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults-preservepath.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "Fonts/SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults.swift
@@ -8,7 +8,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +47,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Fonts/swift4-context-defaults.swift
+++ b/Tests/Expected/Fonts/swift4-context-defaults.swift
@@ -8,7 +8,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -47,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum FontFamily {
   enum SFNSDisplay {
     static let black = FontConvertible(name: ".SFNSDisplay-Black", family: ".SF NS Display", path: "SFNSDisplay-Black.otf")

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-customname.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,9 +51,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-customname.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,7 +50,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all-ignore-module.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,7 +50,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift2-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift2-context-all.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,9 +51,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,9 +51,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-customname.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,7 +50,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all-ignore-module.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,7 +50,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift3-context-all.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -50,9 +51,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-customname.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -53,9 +54,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-customname.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -53,7 +53,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,9 +53,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,7 +52,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,7 +52,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all-ignore-module.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,9 +53,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all.swift
@@ -1,13 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -53,7 +53,9 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-iOS/swift4-context-all.swift
+++ b/Tests/Expected/Storyboards-iOS/swift4-context-all.swift
@@ -1,13 +1,14 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import UIKit
 import CustomSegue
 import LocationPicker
 import SlackTextViewController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -53,9 +54,7 @@ extension UIViewController {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-customname.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-customname.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,7 +48,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,9 +49,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,7 +48,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all-ignore-module.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,9 +49,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift2-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift2-context-all.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-customname.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,7 +48,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,9 +49,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,7 +48,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all-ignore-module.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -48,9 +49,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,9 +50,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift3-context-all.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -49,7 +49,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-customname.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,9 +53,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-customname.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-customname.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,7 +52,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTStoryboardsScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -51,9 +52,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module-need-extra-definitions.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -51,7 +51,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module.swift
@@ -1,11 +1,11 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -51,7 +51,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all-ignore-module.swift
@@ -1,11 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -51,9 +52,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all.swift
@@ -1,12 +1,13 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,9 +53,7 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Storyboards-macOS/swift4-context-all.swift
+++ b/Tests/Expected/Storyboards-macOS/swift4-context-all.swift
@@ -1,12 +1,12 @@
 // Generated using SwiftGen, by O.Halligon — https://github.com/SwiftGen/SwiftGen
 
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import Cocoa
 import FadeSegue
 import PrefsWindowController
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 protocol StoryboardType {
   static var storyboardName: String { get }
@@ -52,7 +52,9 @@ extension NSSeguePerforming {
   }
 }
 
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum StoryboardScene {
   enum AdditionalImport: StoryboardType {
     static let storyboardName = "AdditionalImport"

--- a/Tests/Expected/Strings/flat-swift2-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable-customname.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift2-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable-customname.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift2-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable-no-comments.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   static let AlertMessage = L10n.tr("Localizable", "alert_message")
   static let AlertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift2-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable-no-comments.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let AlertMessage = L10n.tr("Localizable", "alert_message")
   static let AlertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift2-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift2-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-localizable.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift2-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-multiple.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/flat-swift2-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift2-context-multiple.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable-customname.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift3-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable-customname.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift3-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable-no-comments.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift3-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-localizable.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-multiple.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/flat-swift3-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift3-context-multiple.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable-customname.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift4-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable-customname.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift4-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable-no-comments.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift4-context-localizable.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-localizable.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-multiple.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/flat-swift4-context-multiple.swift
+++ b/Tests/Expected/Strings/flat-swift4-context-multiple.swift
@@ -2,9 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift2-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable-customname.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift2-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable-customname.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let AlertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift2-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable-no-comments.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let AlertMessage = L10n.tr("Localizable", "alert_message")
   static let AlertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift2-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable-no-comments.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   static let AlertMessage = L10n.tr("Localizable", "alert_message")
   static let AlertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift2-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift2-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-localizable.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let AlertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift2-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-multiple.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift2-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift2-context-multiple.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable-customname.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift3-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable-customname.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift3-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable-no-comments.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift3-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-localizable.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-multiple.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift3-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift3-context-multiple.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable-customname.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift4-context-localizable-customname.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable-customname.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum XCTLoc {
   /// Some alert body there
   static let alertMessage = XCTLoc.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift4-context-localizable-no-comments.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable-no-comments.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   static let alertMessage = L10n.tr("Localizable", "alert_message")
   static let alertTitle = L10n.tr("Localizable", "alert_title")

--- a/Tests/Expected/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift4-context-localizable.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-localizable.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   /// Some alert body there
   static let alertMessage = L10n.tr("Localizable", "alert_message")

--- a/Tests/Expected/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-multiple.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/Strings/structured-swift4-context-multiple.swift
+++ b/Tests/Expected/Strings/structured-swift4-context-multiple.swift
@@ -2,11 +2,10 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 enum L10n {
   enum Localizable {
     /// Some alert body there

--- a/Tests/Expected/XCAssets/swift2-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-customname.swift
@@ -8,7 +8,7 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -34,7 +34,7 @@ struct XCTColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -47,7 +47,7 @@ enum XCTAssets {
       static let Tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.Background,
       _24Vision.Primary,
@@ -78,7 +78,7 @@ enum XCTAssets {
     }
     static let Private = XCTImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift2-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-customname.swift
@@ -8,7 +8,8 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -34,7 +35,7 @@ struct XCTColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -47,7 +48,7 @@ enum XCTAssets {
       static let Tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.Background,
       _24Vision.Primary,
@@ -78,7 +79,7 @@ enum XCTAssets {
     }
     static let Private = XCTImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
@@ -8,7 +8,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -34,7 +35,7 @@ struct ColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
@@ -8,7 +8,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -34,7 +34,7 @@ struct ColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift2-context-all.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all.swift
@@ -8,7 +8,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -34,7 +35,7 @@ struct ColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -47,7 +48,7 @@ enum Asset {
       static let Tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.Background,
       _24Vision.Primary,
@@ -78,7 +79,7 @@ enum Asset {
     }
     static let Private = ImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/Tests/Expected/XCAssets/swift2-context-all.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all.swift
@@ -8,7 +8,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -34,7 +34,7 @@ struct ColorAsset {
   fileprivate var name: String
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -47,7 +47,7 @@ enum Asset {
       static let Tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.Background,
       _24Vision.Primary,
@@ -78,7 +78,7 @@ enum Asset {
     }
     static let Private = ImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/Tests/Expected/XCAssets/swift3-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-customname.swift
@@ -10,7 +10,8 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -43,7 +44,7 @@ struct XCTColorAsset {
   #endif
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -56,7 +57,7 @@ enum XCTAssets {
       static let tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -87,7 +88,7 @@ enum XCTAssets {
     }
     static let `private` = XCTImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift3-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-customname.swift
@@ -10,7 +10,7 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -43,7 +43,7 @@ struct XCTColorAsset {
   #endif
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -56,7 +56,7 @@ enum XCTAssets {
       static let tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -87,7 +87,7 @@ enum XCTAssets {
     }
     static let `private` = XCTImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
@@ -10,7 +10,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -43,7 +43,7 @@ struct ColorAsset {
   #endif
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
@@ -10,7 +10,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -43,7 +44,7 @@ struct ColorAsset {
   #endif
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift3-context-all.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all.swift
@@ -10,7 +10,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -43,7 +43,7 @@ struct ColorAsset {
   #endif
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -56,7 +56,7 @@ enum Asset {
       static let tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -87,7 +87,7 @@ enum Asset {
     }
     static let `private` = ImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/Tests/Expected/XCAssets/swift3-context-all.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all.swift
@@ -10,7 +10,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -43,7 +44,7 @@ struct ColorAsset {
   #endif
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -56,7 +57,7 @@ enum Asset {
       static let tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -87,7 +88,7 @@ enum Asset {
     }
     static let `private` = ImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/Tests/Expected/XCAssets/swift4-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-customname.swift
@@ -10,7 +10,8 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -41,7 +42,7 @@ struct XCTColorAsset {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -54,7 +55,7 @@ enum XCTAssets {
       static let tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -85,7 +86,7 @@ enum XCTAssets {
     }
     static let `private` = XCTImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift4-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-customname.swift
@@ -10,7 +10,7 @@
   typealias XCTImage = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "XCTImageAsset")
 typealias XCTAssetsType = XCTImageAsset
@@ -41,7 +41,7 @@ struct XCTColorAsset {
   }
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum XCTAssets {
   enum Colors {
     enum _24Vision {
@@ -54,7 +54,7 @@ enum XCTAssets {
       static let tint = XCTColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -85,7 +85,7 @@ enum XCTAssets {
     }
     static let `private` = XCTImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [XCTColorAsset] = [
     ]
     static let allImages: [XCTImageAsset] = [

--- a/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
@@ -10,7 +10,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -41,7 +42,7 @@ struct ColorAsset {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
@@ -10,7 +10,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -41,7 +41,7 @@ struct ColorAsset {
   }
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {

--- a/Tests/Expected/XCAssets/swift4-context-all.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all.swift
@@ -10,7 +10,8 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -41,7 +42,7 @@ struct ColorAsset {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -54,7 +55,7 @@ enum Asset {
       static let tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -85,7 +86,7 @@ enum Asset {
     }
     static let `private` = ImageAsset(name: "private")
 
-    // swiftlint:disable superfluous_disable_command trailing_comma
+    // swiftlint:disable trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/Tests/Expected/XCAssets/swift4-context-all.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all.swift
@@ -10,7 +10,7 @@
   typealias Image = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 @available(*, deprecated, renamed: "ImageAsset")
 typealias AssetType = ImageAsset
@@ -41,7 +41,7 @@ struct ColorAsset {
   }
 }
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum Asset {
   enum Colors {
     enum _24Vision {
@@ -54,7 +54,7 @@ enum Asset {
       static let tint = ColorAsset(name: "Vengo/Tint")
     }
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
       _24Vision.background,
       _24Vision.primary,
@@ -85,7 +85,7 @@ enum Asset {
     }
     static let `private` = ImageAsset(name: "private")
 
-    // swiftlint:disable trailing_comma
+    // swiftlint:disable superfluous_disable_command trailing_comma
     static let allColors: [ColorAsset] = [
     ]
     static let allImages: [ImageAsset] = [

--- a/templates/colors/literals-swift3.stencil
+++ b/templates/colors/literals-swift3.stencil
@@ -10,9 +10,10 @@
   {% if enumName != 'UIColor' %}enum {{enumName}} { }{% endif %}
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
 {% macro enumBlock colors sp %}

--- a/templates/colors/literals-swift3.stencil
+++ b/templates/colors/literals-swift3.stencil
@@ -10,9 +10,9 @@
   {% if enumName != 'UIColor' %}enum {{enumName}} { }{% endif %}
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
 {% macro enumBlock colors sp %}

--- a/templates/colors/literals-swift4.stencil
+++ b/templates/colors/literals-swift4.stencil
@@ -10,9 +10,10 @@
   {% if enumName != 'UIColor' %}enum {{enumName}} { }{% endif %}
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
 {% macro enumBlock colors sp %}

--- a/templates/colors/literals-swift4.stencil
+++ b/templates/colors/literals-swift4.stencil
@@ -10,9 +10,9 @@
   {% if enumName != 'UIColor' %}enum {{enumName}} { }{% endif %}
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 extension {{enumName}} {
 {% macro h2f hex %}{{hex|hexToInt|int255toFloat}}{% endmacro %}
 {% macro enumBlock colors sp %}

--- a/templates/colors/swift2.stencil
+++ b/templates/colors/swift2.stencil
@@ -10,9 +10,10 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +26,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/colors/swift2.stencil
+++ b/templates/colors/swift2.stencil
@@ -10,9 +10,9 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +25,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -10,9 +10,10 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +26,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/colors/swift3.stencil
+++ b/templates/colors/swift3.stencil
@@ -10,9 +10,9 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +25,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -10,9 +10,10 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
-// swiftlint:disable superfluous_disable_command operator_usage_whitespace
+// swiftlint:disable operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +26,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/colors/swift4.stencil
+++ b/templates/colors/swift4.stencil
@@ -10,9 +10,9 @@
   typealias {{colorAlias}} = UIColor
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
-// swiftlint:disable operator_usage_whitespace
+// swiftlint:disable superfluous_disable_command operator_usage_whitespace
 extension {{colorAlias}} {
   convenience init(rgbaValue: UInt32) {
     let red   = CGFloat((rgbaValue >> 24) & 0xff) / 255.0
@@ -25,7 +25,7 @@ extension {{colorAlias}} {
 }
 // swiftlint:enable operator_usage_whitespace
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"ColorName"}}{% endset %}
 struct {{enumName}} {
   let rgbaValue: UInt32

--- a/templates/fonts/swift2.stencil
+++ b/templates/fonts/swift2.stencil
@@ -9,7 +9,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +49,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/fonts/swift2.stencil
+++ b/templates/fonts/swift2.stencil
@@ -9,7 +9,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -9,7 +9,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +49,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/fonts/swift3.stencil
+++ b/templates/fonts/swift3.stencil
@@ -9,7 +9,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -9,7 +9,8 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +49,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/fonts/swift4.stencil
+++ b/templates/fonts/swift4.stencil
@@ -9,7 +9,7 @@
   typealias Font = UIFont
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 struct FontConvertible {
   let name: String
@@ -48,7 +48,7 @@ extension Font {
   }
 }
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name line_length type_body_length
 {% macro transformPath path %}{% filter removeNewlines %}
   {% if param.preservePath %}
     {{path}}

--- a/templates/storyboards/swift2.stencil
+++ b/templates/storyboards/swift2.stencil
@@ -4,14 +4,14 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -56,7 +56,9 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/storyboards/swift2.stencil
+++ b/templates/storyboards/swift2.stencil
@@ -4,14 +4,15 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -56,9 +57,7 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/storyboards/swift3.stencil
+++ b/templates/storyboards/swift3.stencil
@@ -4,14 +4,14 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -56,7 +56,9 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/storyboards/swift3.stencil
+++ b/templates/storyboards/swift3.stencil
@@ -4,14 +4,15 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -56,9 +57,7 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/storyboards/swift4.stencil
+++ b/templates/storyboards/swift4.stencil
@@ -4,14 +4,14 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable sorted_imports
+// swiftlint:disable superfluous_disable_command sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -59,7 +59,9 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/storyboards/swift4.stencil
+++ b/templates/storyboards/swift4.stencil
@@ -4,14 +4,15 @@
 {% set isAppKit %}{% if platform == "macOS" %}true{% endif %}{% endset %}
 {% set prefix %}{% if isAppKit %}NS{% else %}UI{% endif %}{% endset %}
 {% set controller %}{% if isAppKit %}Controller{% else %}ViewController{% endif %}{% endset %}
-// swiftlint:disable superfluous_disable_command sorted_imports
+// swiftlint:disable sorted_imports
 import Foundation
 import {% if isAppKit %}Cocoa{% else %}UIKit{% endif %}
 {% for module in modules where module != env.PRODUCT_MODULE_NAME and module != param.module %}
 import {{module}}
 {% endfor %}
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {# This first part of the code is static, same every time whatever Storyboard you have #}
 protocol StoryboardType {
@@ -59,9 +60,7 @@ extension {% if isAppKit %}NSSeguePerforming{% else %}UIViewController{% endif %
 }
 
 {# This is where the generation begins, this code depends on what you have in your Storyboards #}
-// swiftlint:disable superfluous_disable_command explicit_type_interface
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length type_body_length type_name
 {% set sceneEnumName %}{{param.sceneEnumName|default:"StoryboardScene"}}{% endset %}
 {% macro className scene %}{% filter removeNewlines %}
   {% if scene.customClass %}

--- a/templates/strings/flat-swift2.stencil
+++ b/templates/strings/flat-swift2.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,8 +33,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/flat-swift2.stencil
+++ b/templates/strings/flat-swift2.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,7 +32,8 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,8 +33,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/flat-swift3.stencil
+++ b/templates/strings/flat-swift3.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,7 +32,8 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,8 +33,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable identifier_name line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/flat-swift4.stencil
+++ b/templates/strings/flat-swift4.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -32,7 +32,8 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length type_body_length
+// swiftlint:disable superfluous_disable_command identifier_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift2.stencil
+++ b/templates/strings/structured-swift2.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,7 +36,9 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift2.stencil
+++ b/templates/strings/structured-swift2.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,9 +37,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,7 +36,9 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift3.stencil
+++ b/templates/strings/structured-swift3.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,9 +37,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -3,7 +3,7 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,7 +36,9 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
+// swiftlint:disable superfluous_disable_command identifier_name type_name
+// swiftlint:disable superfluous_disable_command line_length type_body_length
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/strings/structured-swift4.stencil
+++ b/templates/strings/structured-swift4.stencil
@@ -3,7 +3,8 @@
 {% if tables.count > 0 %}
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 {% macro parametersBlock types %}{% filter removeNewlines:"leading" %}
   {% for type in types %}
     _ p{{forloop.counter}}: {{type}}{% if not forloop.last %}, {% endif %}
@@ -36,9 +37,7 @@ import Foundation
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command explicit_type_interface nesting
-// swiftlint:disable superfluous_disable_command identifier_name type_name
-// swiftlint:disable superfluous_disable_command line_length type_body_length
+// swiftlint:disable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 {% set enumName %}{{param.enumName|default:"L10n"}}{% endset %}
 enum {{enumName}} {
   {% if tables.count > 1 %}

--- a/templates/xcassets/swift2.stencil
+++ b/templates/xcassets/swift2.stencil
@@ -10,7 +10,7 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -42,7 +42,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable trailing_comma
+{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -81,7 +81,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}

--- a/templates/xcassets/swift2.stencil
+++ b/templates/xcassets/swift2.stencil
@@ -10,7 +10,8 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -42,7 +43,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
+{{sp}}  // swiftlint:disable trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -81,7 +82,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -13,7 +13,8 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -52,7 +53,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
+{{sp}}  // swiftlint:disable trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -91,7 +92,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -13,7 +13,7 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -52,7 +52,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable trailing_comma
+{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -91,7 +91,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -13,7 +13,7 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -50,7 +50,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable trailing_comma
+{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -89,7 +89,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -13,7 +13,8 @@
   typealias {{imageAlias}} = UIImage
 #endif
 
-// swiftlint:disable superfluous_disable_command file_length
+// swiftlint:disable superfluous_disable_command
+// swiftlint:disable file_length
 
 {% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
 {% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
@@ -50,7 +51,7 @@ struct {{colorType}} {
 {{sp}}  {% call casesBlock assets sp %}
 {{sp}}  {% if not param.noAllValues %}
 
-{{sp}}  // swiftlint:disable superfluous_disable_command trailing_comma
+{{sp}}  // swiftlint:disable trailing_comma
 {{sp}}  static let allColors: [{{colorType}}] = [
 {{sp}}    {% set sp2 %}{{sp}}  {% endset %}
 {{sp}}    {% call allValuesBlock assets "color" "" sp2 %}
@@ -89,7 +90,7 @@ struct {{colorType}} {
 {{sp}}  {% endfor %}
 {% endmacro %}
 
-// swiftlint:disable superfluous_disable_command identifier_name line_length nesting type_body_length type_name
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
 enum {{enumName}} {
   {% if catalogs.count > 1 %}
   {% for catalog in catalogs %}


### PR DESCRIPTION
Fixes SwiftGen/SwiftGen#334

Avoids new warning in SwiftLint >0.22

Sadly, it seems that the only way for this exception to work is to repeat it on _every_ `swiftlint:disable` annotation. As mentioned in SwiftGen/SwiftGen#334, disabling it once at the beginning on the files doesn't seem to have any effect, it seems to only have effect to the rule we're currently disabling, hence it having to be repeated every time :-/

I also had to break down some `// swiftlint:disable` lines, disabling multiple rules at once, into multiple separate `// swiftlint:disable` lines now, since ironically those lines disable 4-5 rules at once began to be too long… triggering the "line too long" SwiftLint warning (I don't think this issue could have been more meta at that point ^^)