### PR TITLE
Hotfix/expose image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ _None_
 
 _None_
 
+## 2.2.1
+
+### Bug Fixes
+
+* XCAssets: exposed getter for image name string.  
+  [Abbey Jackson](https://github.com/abbeyjackson)
+  [#85](https://github.com/SwiftGen/templates/pull/85)
+
 ## 2.2.0
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ### Bug Fixes
 
-_None_
+* XCAssets: exposed getter for image name string.  
+  [Abbey Jackson](https://github.com/abbeyjackson)
+  [#85](https://github.com/SwiftGen/templates/pull/85)
 
 ### Breaking Changes
 
@@ -19,14 +21,6 @@ _None_
 ### Internal Changes
 
 _None_
-
-## 2.2.1
-
-### Bug Fixes
-
-* XCAssets: exposed getter for image name string.  
-  [Abbey Jackson](https://github.com/abbeyjackson)
-  [#85](https://github.com/SwiftGen/templates/pull/85)
 
 ## 2.2.0
 

--- a/Tests/Expected/XCAssets/swift2-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-customname.swift
@@ -15,7 +15,7 @@
 typealias XCTAssetsType = XCTImageAsset
 
 struct XCTImageAsset {
-  private var name: String
+  private(set) var name: String
 
   var image: XCTImage {
     let bundle = NSBundle(forClass: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
@@ -15,7 +15,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  private var name: String
+  private(set) var name: String
 
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift2-context-all.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all.swift
@@ -15,7 +15,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  private var name: String
+  private(set) var name: String
 
   var image: Image {
     let bundle = NSBundle(forClass: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift3-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-customname.swift
@@ -17,7 +17,7 @@
 typealias XCTAssetsType = XCTImageAsset
 
 struct XCTImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: XCTImage {
     let bundle = Bundle(for: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
@@ -17,7 +17,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift3-context-all.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all.swift
@@ -17,7 +17,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift4-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-customname.swift
@@ -17,7 +17,7 @@
 typealias XCTAssetsType = XCTImageAsset
 
 struct XCTImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: XCTImage {
     let bundle = Bundle(for: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
@@ -17,7 +17,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)

--- a/Tests/Expected/XCAssets/swift4-context-all.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all.swift
@@ -17,7 +17,7 @@
 typealias AssetType = ImageAsset
 
 struct ImageAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: Image {
     let bundle = Bundle(for: BundleToken.self)

--- a/templates/xcassets/swift2.stencil
+++ b/templates/xcassets/swift2.stencil
@@ -19,7 +19,7 @@
 typealias {{enumName}}Type = {{imageType}}
 
 struct {{imageType}} {
-  private var name: String
+  private(set) var name: String
 
   var image: {{imageAlias}} {
     let bundle = NSBundle(forClass: BundleToken.self)

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -22,7 +22,7 @@
 typealias {{enumName}}Type = {{imageType}}
 
 struct {{imageType}} {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: {{imageAlias}} {
     let bundle = Bundle(for: BundleToken.self)

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -22,7 +22,7 @@
 typealias {{enumName}}Type = {{imageType}}
 
 struct {{imageType}} {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   var image: {{imageAlias}} {
     let bundle = Bundle(for: BundleToken.self)


### PR DESCRIPTION
Change private access to private(set) in order to expose image name on swift2.stencil, swift3.stencil and swift4.stencil for the xcassets folder.