### PR TITLE
Trying to fix CircleCI not finding Xcode 9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'English'
 WORKSPACE = 'Templates'.freeze
 SCHEME_NAME = 'Tests'.freeze
 CONFIGURATION = 'Debug'.freeze
-MIN_XCODE_VERSION = 9.0
+MIN_XCODE_VERSION = '~> 9.0'
 
 ## [ Output compilation ] #####################################################
 

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     version: 9.0
   pre:
   - sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
+  - mdimport /Applications/Xcode*
+
 
 dependencies:
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,6 @@
 machine:
   xcode:
     version: 9.0
-  pre:
-  - sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.metadata.mds.plist
-  - mdimport /Applications/Xcode*
-
 
 dependencies:
   post:

--- a/rakelib/utils.rake
+++ b/rakelib/utils.rake
@@ -126,28 +126,32 @@ class Utils
 
   # select the xcode version we want/support
   def self.version_select
-    @@version_select ||= compute_developer_dir(MIN_XCODE_VERSION) # rubocop:disable Style/ClassVars
+    @version_select ||= compute_developer_dir(MIN_XCODE_VERSION)
   end
   private_class_method :version_select
 
-  def self.compute_developer_dir(min_version)
+  def self.compute_developer_dir(version_req)
+    version_req = Gem::Requirement.new(version_req) unless version_req.is_a?(Gem::Requirement)
     # if current Xcode already fulfills min version don't force DEVELOPER_DIR=...
-    current_xcode = Pathname.new(`xcode-select -p`).parent.parent
-    current_xcode_version = `mdls -name kMDItemVersion -raw "#{current_xcode}"`.chomp
-    return '' if current_xcode_version.to_f >= min_version.to_f
+    current_xcode_version = `xcodebuild -version`.split("\n").first.match(/[0-9.]+/).to_s
+    return '' if version_req.satisfied_by? Gem::Version.new(current_xcode_version)
 
     # Get all available Xcodes, order by version, get the latest one
     xcodes = `mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"`.chomp.split("\n")
-    versions = xcodes.map { |path| { vers: `mdls -name kMDItemVersion -raw "#{path}"`, path: path } }
-    latest_xcode = versions.sort_by { |a| a[:vers] }.last
+    all_versions = xcodes.map do |path|
+      { vers: Gem::Version.new(`mdls -name kMDItemVersion -raw "#{path}"`), path: path }
+    end
+    supported_versions = all_versions.select { |app| version_req.satisfied_by?(app[:vers]) }
+    latest_supported_xcode = supported_versions.sort_by { |app| app[:vers] }.last
 
     # Check if it's at least the right version
-    if latest_xcode.nil? || latest_xcode[:vers].to_f < min_version
-      raise "\n[!!!] SwiftGen requires Xcode #{MIN_XCODE_VERSION}, but we were not able to find it. " \
-        "If it's already installed update your Spotlight index with 'mdimport /Applications/Xcode*'\n\n"
+    if latest_supported_xcode.nil?
+      raise "\n[!!!] SwiftGen requires Xcode #{version_req}, but we were not able to find it. " \
+        "If it's already installed, either `xcode-select -s` to it, or update your Spotlight index " \
+        "with 'mdimport /Applications/Xcode*'\n\n"
     end
 
-    %(DEVELOPER_DIR="#{latest_xcode[:path]}/Contents/Developer")
+    %(DEVELOPER_DIR="#{latest_supported_xcode[:path]}/Contents/Developer")
   end
   private_class_method :compute_developer_dir
 end

--- a/rakelib/utils.rake
+++ b/rakelib/utils.rake
@@ -134,13 +134,11 @@ class Utils
     # if current Xcode already fulfills min version don't force DEVELOPER_DIR=...
     current_xcode = Pathname.new(`xcode-select -p`).parent.parent
     current_xcode_version = `mdls -name kMDItemVersion -raw "#{current_xcode}"`.chomp
-    puts "Current Xcode: #{current_xcode} (#{current_xcode_version})"
     return '' if current_xcode_version.to_f >= min_version.to_f
 
     # Get all available Xcodes, order by version, get the latest one
     xcodes = `mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"`.chomp.split("\n")
     versions = xcodes.map { |path| { vers: `mdls -name kMDItemVersion -raw "#{path}"`, path: path } }
-    puts "Found versions: #{versions}"
     latest_xcode = versions.sort_by { |a| a[:vers] }.last
 
     # Check if it's at least the right version

--- a/rakelib/utils.rake
+++ b/rakelib/utils.rake
@@ -134,11 +134,13 @@ class Utils
     # if current Xcode already fulfills min version don't force DEVELOPER_DIR=...
     current_xcode = Pathname.new(`xcode-select -p`).parent.parent
     current_xcode_version = `mdls -name kMDItemVersion -raw "#{current_xcode}"`.chomp
+    puts "Current Xcode: #{current_xcode} (#{current_xcode_version})"
     return '' if current_xcode_version.to_f >= min_version.to_f
 
     # Get all available Xcodes, order by version, get the latest one
     xcodes = `mdfind "kMDItemCFBundleIdentifier = 'com.apple.dt.Xcode'"`.chomp.split("\n")
     versions = xcodes.map { |path| { vers: `mdls -name kMDItemVersion -raw "#{path}"`, path: path } }
+    puts "Found versions: #{versions}"
     latest_xcode = versions.sort_by { |a| a[:vers] }.last
 
     # Check if it's at least the right version


### PR DESCRIPTION
Seems like recent builds on CI fail to find Xcode 9.

That `mdimport` trick solved it in SwiftGen/SwiftGen, so applying it here too.