### PR TITLE
allow access to name property on color assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ _None_
 
 ### New Features
 
-_None_
+* XCAssets: exposed getter for color name string.  
+  [Stephan Diederich](https://github.com/diederich)
+  [#87](https://github.com/SwiftGen/templates/pull/87)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@
 
 ### Bug Fixes
 
-* XCAssets: exposed getter for image name string.  
-  [Abbey Jackson](https://github.com/abbeyjackson)
-  [#85](https://github.com/SwiftGen/templates/pull/85)
+_None_
 
 ### Breaking Changes
 
@@ -16,6 +14,9 @@ _None_
 
 ### New Features
 
+* XCAssets: exposed getter for image name string.  
+  [Abbey Jackson](https://github.com/abbeyjackson)
+  [#85](https://github.com/SwiftGen/templates/pull/85)
 * XCAssets: exposed getter for color name string.  
   [Stephan Diederich](https://github.com/diederich)
   [#87](https://github.com/SwiftGen/templates/pull/87)

--- a/Tests/Expected/XCAssets/swift2-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-customname.swift
@@ -32,7 +32,7 @@ struct XCTImageAsset {
 }
 
 struct XCTColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 }
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name

--- a/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all-no-all-values.swift
@@ -32,7 +32,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 }
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name

--- a/Tests/Expected/XCAssets/swift2-context-all.swift
+++ b/Tests/Expected/XCAssets/swift2-context-all.swift
@@ -32,7 +32,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 }
 
 // swiftlint:disable identifier_name line_length nesting type_body_length type_name

--- a/Tests/Expected/XCAssets/swift3-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-customname.swift
@@ -34,7 +34,7 @@ struct XCTImageAsset {
 }
 
 struct XCTColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)

--- a/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all-no-all-values.swift
@@ -34,7 +34,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)

--- a/Tests/Expected/XCAssets/swift3-context-all.swift
+++ b/Tests/Expected/XCAssets/swift3-context-all.swift
@@ -34,7 +34,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)

--- a/Tests/Expected/XCAssets/swift4-context-all-customname.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-customname.swift
@@ -34,7 +34,7 @@ struct XCTImageAsset {
 }
 
 struct XCTColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
   var color: XCTColor {

--- a/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all-no-all-values.swift
@@ -34,7 +34,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
   var color: AssetColorTypeAlias {

--- a/Tests/Expected/XCAssets/swift4-context-all.swift
+++ b/Tests/Expected/XCAssets/swift4-context-all.swift
@@ -34,7 +34,7 @@ struct ImageAsset {
 }
 
 struct ColorAsset {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
   var color: AssetColorTypeAlias {

--- a/templates/xcassets/swift2.stencil
+++ b/templates/xcassets/swift2.stencil
@@ -37,7 +37,7 @@ struct {{imageType}} {
 
 {% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
 struct {{colorType}} {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 }
 {% macro enumBlock assets sp %}
 {{sp}}  {% call casesBlock assets sp %}

--- a/templates/xcassets/swift3.stencil
+++ b/templates/xcassets/swift3.stencil
@@ -40,7 +40,7 @@ struct {{imageType}} {
 
 {% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
 struct {{colorType}} {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   #if swift(>=3.2)
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)

--- a/templates/xcassets/swift4.stencil
+++ b/templates/xcassets/swift4.stencil
@@ -40,7 +40,7 @@ struct {{imageType}} {
 
 {% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
 struct {{colorType}} {
-  fileprivate var name: String
+  fileprivate(set) var name: String
 
   @available(iOS 11.0, tvOS 11.0, watchOS 4.0, OSX 10.13, *)
   var color: {{colorAlias}} {


### PR DESCRIPTION
allow access to the name of the color asset,
e.g. to show a list of all colors used in the app.
See #85 for the same on images.